### PR TITLE
HDDS-12810. make volume space check and reservation as an atomic operation in volume choosing policy

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/ContainerData.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/ContainerData.java
@@ -29,7 +29,6 @@ import static org.apache.hadoop.ozone.OzoneConsts.ORIGIN_PIPELINE_ID;
 import static org.apache.hadoop.ozone.OzoneConsts.STATE;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import jakarta.annotation.Nullable;
@@ -214,21 +213,14 @@ public abstract class ContainerData {
         (state != oldState)) {
       releaseCommitSpace();
     }
-
-    /**
-     * commit space when container transitions (back) to Open.
-     * when? perhaps closing a container threw an exception
-     */
-    if ((state == ContainerDataProto.State.OPEN) &&
-        (state != oldState)) {
-      Preconditions.checkState(getMaxSize() > 0);
-      commitSpace();
-    }
   }
 
-  @VisibleForTesting
-  void setCommittedSpace(boolean committedSpace) {
-    this.committedSpace = committedSpace;
+  public void setCommittedSpace(boolean committed) {
+    if (committed) {
+      //we don't expect duplicate space commit
+      Preconditions.checkState(!committedSpace);
+    }
+    committedSpace = committed;
   }
 
   /**
@@ -356,7 +348,7 @@ public abstract class ContainerData {
     setState(ContainerDataProto.State.CLOSED);
   }
 
-  private void releaseCommitSpace() {
+  public void releaseCommitSpace() {
     long unused = getMaxSize() - getBytesUsed();
 
     // only if container size < max size

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/ContainerData.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/ContainerData.java
@@ -215,6 +215,10 @@ public abstract class ContainerData {
     }
   }
 
+  public boolean isCommittedSpace() {
+    return committedSpace;
+  }
+
   public void setCommittedSpace(boolean committed) {
     if (committed) {
       //we don't expect duplicate space commit

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/ContainerSet.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/ContainerSet.java
@@ -154,8 +154,6 @@ public class ContainerSet implements Iterable<Container<?>> {
         throw new StorageContainerException(e, ContainerProtos.Result.IO_EXCEPTION);
       }
       missingContainerSet.remove(containerId);
-      // wish we could have done this from ContainerData.setState
-      container.getContainerData().commitSpace();
       if (container.getContainerData().getState() == RECOVERING) {
         recoveringContainerMap.put(
             clock.millis() + recoveringTimeout, containerId);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/CapacityVolumeChoosingPolicy.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/CapacityVolumeChoosingPolicy.java
@@ -69,9 +69,8 @@ public class CapacityVolumeChoosingPolicy implements VolumeChoosingPolicy {
     }
 
     int count = volumesWithEnoughSpace.size();
-    if (count == 1) {
-      return volumesWithEnoughSpace.get(0);
-    } else {
+    HddsVolume selectedVolume = volumesWithEnoughSpace.get(0);
+    if (count > 1) {
       // Even if we don't have too many volumes in volumesWithEnoughSpace, this
       // algorithm will still help us choose the volume with larger
       // available space than other volumes.
@@ -93,10 +92,9 @@ public class CapacityVolumeChoosingPolicy implements VolumeChoosingPolicy {
           - firstVolume.getCommittedBytes();
       long secondAvailable = secondVolume.getCurrentUsage().getAvailable()
           - secondVolume.getCommittedBytes();
-      HddsVolume selectedVolume = firstAvailable < secondAvailable ? secondVolume : firstVolume;
-
-      selectedVolume.incCommittedBytes(maxContainerSize);
-      return selectedVolume;
+      selectedVolume = firstAvailable < secondAvailable ? secondVolume : firstVolume;
     }
+    selectedVolume.incCommittedBytes(maxContainerSize);
+    return selectedVolume;
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/CapacityVolumeChoosingPolicy.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/CapacityVolumeChoosingPolicy.java
@@ -48,7 +48,7 @@ public class CapacityVolumeChoosingPolicy implements VolumeChoosingPolicy {
   private final Random random = new Random();
 
   @Override
-  public HddsVolume chooseVolume(List<HddsVolume> volumes,
+  public synchronized HddsVolume chooseVolume(List<HddsVolume> volumes,
       long maxContainerSize) throws IOException {
 
     // No volumes available to choose from
@@ -93,7 +93,10 @@ public class CapacityVolumeChoosingPolicy implements VolumeChoosingPolicy {
           - firstVolume.getCommittedBytes();
       long secondAvailable = secondVolume.getCurrentUsage().getAvailable()
           - secondVolume.getCommittedBytes();
-      return firstAvailable < secondAvailable ? secondVolume : firstVolume;
+      HddsVolume selectedVolume = firstAvailable < secondAvailable ? secondVolume : firstVolume;
+
+      selectedVolume.incCommittedBytes(maxContainerSize);
+      return selectedVolume;
     }
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/RoundRobinVolumeChoosingPolicy.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/RoundRobinVolumeChoosingPolicy.java
@@ -41,7 +41,7 @@ public class RoundRobinVolumeChoosingPolicy implements VolumeChoosingPolicy {
   private AtomicInteger nextVolumeIndex = new AtomicInteger(0);
 
   @Override
-  public HddsVolume chooseVolume(List<HddsVolume> volumes,
+  public synchronized HddsVolume chooseVolume(List<HddsVolume> volumes,
       long maxContainerSize) throws IOException {
 
     // No volumes available to choose from
@@ -68,6 +68,7 @@ public class RoundRobinVolumeChoosingPolicy implements VolumeChoosingPolicy {
       if (hasEnoughSpace) {
         logIfSomeVolumesOutOfSpace(filter, LOG);
         nextVolumeIndex.compareAndSet(nextIndex, currentVolumeIndex);
+        volume.incCommittedBytes(maxContainerSize);
         return volume;
       }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ContainerImporter.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ContainerImporter.java
@@ -88,7 +88,7 @@ public class ContainerImporter {
   }
 
   public void importContainer(long containerID, Path tarFilePath,
-      HddsVolume hddsVolume, CopyContainerCompression compression)
+      HddsVolume targetVolume, CopyContainerCompression compression)
       throws IOException {
     if (!importContainerProgress.add(containerID)) {
       deleteFileQuietely(tarFilePath);
@@ -104,11 +104,6 @@ public class ContainerImporter {
         LOG.warn(log);
         throw new StorageContainerException(log,
             ContainerProtos.Result.CONTAINER_EXISTS);
-      }
-
-      HddsVolume targetVolume = hddsVolume;
-      if (targetVolume == null) {
-        targetVolume = chooseNextVolume();
       }
 
       KeyValueContainerData containerData;

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerPersistence.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerPersistence.java
@@ -204,10 +204,11 @@ public class TestContainerPersistence {
     data.addMetadata("VOLUME", "shire");
     data.addMetadata("owner)", "bilbo");
     KeyValueContainer container = new KeyValueContainer(data, conf);
+    commitBytesBefore = StorageVolumeUtil.getHddsVolumesList(volumeSet.getVolumesList()).get(0).getCommittedBytes();
+
     container.create(volumeSet, volumeChoosingPolicy, SCM_ID);
-    commitBytesBefore = container.getContainerData()
-        .getVolume().getCommittedBytes();
     cSet.addContainer(container);
+
     commitBytesAfter = container.getContainerData()
         .getVolume().getCommittedBytes();
     commitIncrement = commitBytesAfter - commitBytesBefore;

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestCapacityVolumeChoosingPolicy.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestCapacityVolumeChoosingPolicy.java
@@ -149,4 +149,15 @@ public class TestCapacityVolumeChoosingPolicy {
         VolumeChoosingPolicyFactory.getPolicy(CONF).getClass());
   }
 
+  @Test
+  public void testVolumeCommittedSpace() throws Exception {
+    Map<HddsVolume, Long> initialCommittedSpace = new HashMap<>();
+    volumes.forEach(vol ->
+        initialCommittedSpace.put(vol, vol.getCommittedBytes()));
+
+    HddsVolume selectedVolume = policy.chooseVolume(volumes, 50);
+
+    assertEquals(initialCommittedSpace.get(selectedVolume) + 50,
+        selectedVolume.getCommittedBytes());
+  }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestRoundRobinVolumeChoosingPolicy.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestRoundRobinVolumeChoosingPolicy.java
@@ -25,7 +25,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.fs.MockSpaceUsageCheckFactory;
 import org.apache.hadoop.hdds.fs.MockSpaceUsageSource;
@@ -115,4 +117,15 @@ public class TestRoundRobinVolumeChoosingPolicy {
         "Most available space: 150 bytes");
   }
 
+  @Test
+  public void testVolumeCommittedSpace() throws Exception {
+    Map<HddsVolume, Long> initialCommittedSpace = new HashMap<>();
+    volumes.forEach(vol ->
+        initialCommittedSpace.put(vol, vol.getCommittedBytes()));
+
+    HddsVolume selectedVolume = policy.chooseVolume(volumes, 50);
+
+    assertEquals(initialCommittedSpace.get(selectedVolume) + 50,
+        selectedVolume.getCommittedBytes());
+  }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestDownloadAndImportReplicator.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestDownloadAndImportReplicator.java
@@ -17,9 +17,107 @@
 
 package org.apache.hadoop.ozone.container.replication;
 
+import static org.apache.hadoop.ozone.container.common.impl.ContainerImplTestUtils.newContainerSet;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Semaphore;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.conf.StorageUnit;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.scm.ScmConfigKeys;
+import org.apache.hadoop.ozone.container.common.impl.ContainerSet;
+import org.apache.hadoop.ozone.container.common.interfaces.VolumeChoosingPolicy;
+import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
+import org.apache.hadoop.ozone.container.common.volume.MutableVolumeSet;
+import org.apache.hadoop.ozone.container.common.volume.StorageVolume;
+import org.apache.hadoop.ozone.container.common.volume.VolumeChoosingPolicyFactory;
+import org.apache.hadoop.ozone.container.ozoneimpl.ContainerController;
+import org.apache.ozone.test.GenericTestUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
 /**
  * Test for DownloadAndImportReplicator.
  */
+@Timeout(300)
 public class TestDownloadAndImportReplicator {
-    
+
+  @TempDir
+  private File tempDir;
+
+  private OzoneConfiguration conf;
+  private VolumeChoosingPolicy volumeChoosingPolicy;
+  private ContainerSet containerSet;
+  private MutableVolumeSet volumeSet;
+  private ContainerImporter importer;
+  private SimpleContainerDownloader downloader;
+  private DownloadAndImportReplicator replicator;
+  private long containerMaxSize;
+
+  @BeforeEach
+  void setup() throws IOException {
+    conf = new OzoneConfiguration();
+    conf.set(ScmConfigKeys.HDDS_DATANODE_DIR_KEY, tempDir.getAbsolutePath());
+    volumeChoosingPolicy = VolumeChoosingPolicyFactory.getPolicy(conf);
+    containerSet = newContainerSet(0);
+    volumeSet = new MutableVolumeSet("test", conf, null,
+        StorageVolume.VolumeType.DATA_VOLUME, null);
+    importer = new ContainerImporter(conf, containerSet,
+        mock(ContainerController.class), volumeSet, volumeChoosingPolicy);
+    downloader = mock(SimpleContainerDownloader.class);
+    replicator = new DownloadAndImportReplicator(conf, containerSet, importer,
+        downloader);
+    containerMaxSize = (long) conf.getStorageSize(
+        ScmConfigKeys.OZONE_SCM_CONTAINER_SIZE,
+        ScmConfigKeys.OZONE_SCM_CONTAINER_SIZE_DEFAULT, StorageUnit.BYTES);
+  }
+
+  @Test
+  public void testCommitSpaceReleasedOnReplicationFailure() throws Exception {
+    long containerId = 1;
+    HddsVolume volume = (HddsVolume) volumeSet.getVolumesList().get(0);
+    long initialCommittedBytes = volume.getCommittedBytes();
+
+    // Mock downloader to throw exception
+    Semaphore semaphore = new Semaphore(1);
+    when(downloader.getContainerDataFromReplicas(anyLong(), any(), any(), any()))
+        .thenAnswer(invocation -> {
+          semaphore.acquire();
+          throw new IOException("Download failed");
+        });
+
+    ReplicationTask task = new ReplicationTask(containerId,
+        Collections.singletonList(mock(DatanodeDetails.class)), replicator);
+
+    // Acquire semaphore so that container import will pause before downloading.
+    semaphore.acquire();
+    CompletableFuture.runAsync(() -> {
+      assertThrows(IOException.class, () -> replicator.replicate(task));
+    });
+
+    // Wait such that first container import reserve space
+    GenericTestUtils.waitFor(() ->
+        volume.getCommittedBytes() > initialCommittedBytes,
+        1000, 50000);
+    assertEquals(volume.getCommittedBytes(), initialCommittedBytes + 2 * containerMaxSize);
+    semaphore.release();
+
+    GenericTestUtils.waitFor(() ->
+        volume.getCommittedBytes() == initialCommittedBytes,
+        1000, 50000);
+
+    // Verify commit space is released
+    assertEquals(initialCommittedBytes, volume.getCommittedBytes());
+  }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestDownloadAndImportReplicator.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestDownloadAndImportReplicator.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.container.replication;
+
+/**
+ * Test for DownloadAndImportReplicator.
+ */
+public class TestDownloadAndImportReplicator {
+    
+}

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
@@ -355,11 +355,12 @@ public class TestReplicationSupervisor {
   @ContainerLayoutTestInfo.ContainerTest
   public void testReplicationImportReserveSpace(ContainerLayoutVersion layout)
       throws IOException, InterruptedException, TimeoutException {
+    final long containerUsedSize = 100;
     this.layoutVersion = layout;
     OzoneConfiguration conf = new OzoneConfiguration();
     conf.set(ScmConfigKeys.HDDS_DATANODE_DIR_KEY, tempDir.getAbsolutePath());
 
-    long containerSize = (long) conf.getStorageSize(
+    long containerMaxSize = (long) conf.getStorageSize(
         ScmConfigKeys.OZONE_SCM_CONTAINER_SIZE,
         ScmConfigKeys.OZONE_SCM_CONTAINER_SIZE_DEFAULT, StorageUnit.BYTES);
 
@@ -369,13 +370,16 @@ public class TestReplicationSupervisor {
         .clock(clock)
         .build();
 
+    MutableVolumeSet volumeSet = new MutableVolumeSet(datanode.getUuidString(), conf, null,
+        StorageVolume.VolumeType.DATA_VOLUME, null);
+
     long containerId = 1;
     // create container
     KeyValueContainerData containerData = new KeyValueContainerData(containerId,
-        ContainerLayoutVersion.FILE_PER_BLOCK, 100, "test", "test");
-    HddsVolume vol = mock(HddsVolume.class);
-    containerData.setVolume(vol);
-    containerData.incrBytesUsed(100);
+        ContainerLayoutVersion.FILE_PER_BLOCK, containerMaxSize, "test", "test");
+    HddsVolume vol1 = (HddsVolume) volumeSet.getVolumesList().get(0);
+    containerData.setVolume(vol1);
+    containerData.incrBytesUsed(containerUsedSize);
     KeyValueContainer container = new KeyValueContainer(containerData, conf);
     ContainerController controllerMock = mock(ContainerController.class);
     Semaphore semaphore = new Semaphore(1);
@@ -384,8 +388,7 @@ public class TestReplicationSupervisor {
           semaphore.acquire();
           return container;
         });
-    MutableVolumeSet volumeSet = new MutableVolumeSet(datanode.getUuidString(), conf, null,
-        StorageVolume.VolumeType.DATA_VOLUME, null);
+    
     File tarFile = containerTarFile(containerId, containerData);
 
     SimpleContainerDownloader moc =
@@ -398,14 +401,13 @@ public class TestReplicationSupervisor {
     ContainerImporter importer =
         new ContainerImporter(conf, set, controllerMock, volumeSet, volumeChoosingPolicy);
 
-    HddsVolume vol1 = (HddsVolume) volumeSet.getVolumesList().get(0);
     // Initially volume has 0 commit space
     assertEquals(0, vol1.getCommittedBytes());
     long usedSpace = vol1.getCurrentUsage().getUsedSpace();
     // Initially volume has 0 used space
     assertEquals(0, usedSpace);
     // Increase committed bytes so that volume has only remaining 3 times container size space
-    long initialCommittedBytes = vol1.getCurrentUsage().getCapacity() - containerSize * 3;
+    long initialCommittedBytes = vol1.getCurrentUsage().getCapacity() - containerMaxSize * 3;
     vol1.incCommittedBytes(initialCommittedBytes);
     ContainerReplicator replicator =
         new DownloadAndImportReplicator(conf, set, importer, moc);
@@ -424,11 +426,11 @@ public class TestReplicationSupervisor {
 
     // Wait such that first container import reserve space
     GenericTestUtils.waitFor(() ->
-        vol1.getCommittedBytes() > vol1.getCurrentUsage().getCapacity() - containerSize * 3,
+        vol1.getCommittedBytes() > initialCommittedBytes,
         1000, 50000);
 
     // Volume has reserved space of 2 * containerSize
-    assertEquals(vol1.getCommittedBytes(), initialCommittedBytes + 2 * containerSize);
+    assertEquals(vol1.getCommittedBytes(), initialCommittedBytes + 2 * containerMaxSize);
     // Container 2 import will fail as container 1 has reserved space and no space left to import new container
     // New container import requires at least (2 * container size)
     long containerId2 = 2;
@@ -443,10 +445,11 @@ public class TestReplicationSupervisor {
 
     usedSpace = vol1.getCurrentUsage().getUsedSpace();
     // After replication, volume used space should be increased by container used bytes
-    assertEquals(100, usedSpace);
+    assertEquals(containerUsedSize, usedSpace);
 
-    // Volume committed bytes should become initial committed bytes which was before replication
-    assertEquals(initialCommittedBytes, vol1.getCommittedBytes());
+    // Volume committed bytes used for replication has been released, no need to reserve space for imported container
+    // only closed container gets replicated, so no new data will be written it
+    assertEquals(vol1.getCommittedBytes(), initialCommittedBytes);
 
   }
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestSendContainerRequestHandler.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestSendContainerRequestHandler.java
@@ -49,13 +49,11 @@ import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 import org.apache.ratis.thirdparty.io.grpc.stub.StreamObserver;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Test for {@link SendContainerRequestHandler}.
  */
-@Timeout(300)
 public class TestSendContainerRequestHandler {
 
   @TempDir


### PR DESCRIPTION
## What changes were proposed in this pull request?

If `VolumeChoosingPolicy#chooseVolume` is not synchronized and caller required space reserved before chooseVolume returns, there is no easy way to guarantee chosen volume will have enough space.

`VolumeChoosingPolicy#chooseVolume` is used for create container and container import. Make `VolumeChoosingPolicy#chooseVolume` synchronized or part of chooseVolume synchronized will add some latency, which is negligible for container import, may noticeable for create container. We can compare the create container latency metrics with and without the synchronization.

`VolumeChoosingPolicy#chooseVolume`, its Java Doc says "The implementations of this interface must be thread-safe.", regarding the space full check and space reservation, it can be done as an atomic operation in the chooseVolume internally, so that there will no over allocation of space due to concurrent container creation and container import.

Also need to add test to check if committedBytes is checked in container creation unit tests and container import, container replication unit tests. Besides, we also need the unit tests to verify that if the container creation fails, container import fails, or container replication fails, the resevered committedBytes are released.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12810

## How was this patch tested?

Added coverage of commit space would be reserved/released correctly when creating/importing containers in `TestKeyValueContainer`, `TestDownloadAndImportReplicator` and `TestSendContainerRequestHandler`. There're also some existing tests covering this change, like `TestContainerPerisistance` and `TestOzoneContainer`.