### PR TITLE
Implement S3 Select functionality in Ozone S3 Gateway.

### DIFF
--- a/hadoop-ozone/s3gateway/pom.xml
+++ b/hadoop-ozone/s3gateway/pom.xml
@@ -63,6 +63,11 @@
       <artifactId>picocli</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.github.datafusion-contrib</groupId>
+      <artifactId>datafusion-java</artifactId>
+      <version>0.14.1</version>
+    </dependency>
+    <dependency>
       <groupId>io.opentracing</groupId>
       <artifactId>opentracing-api</artifactId>
     </dependency>
@@ -101,6 +106,16 @@
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.arrow</groupId>
+      <artifactId>arrow-memory-core</artifactId>
+      <version>13.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.arrow</groupId>
+      <artifactId>arrow-vector</artifactId>
+      <version>13.0.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -841,7 +841,7 @@ public class ObjectEndpoint extends EndpointBase {
       SelectObjectContentRequest request = 
           SelectObjectContentRequest.parseFrom(requestBody);
 
-      SelectProcessor processor = new SelectProcessor(getClient(), bucket, keyPath);
+      SelectProcessor processor = new SelectProcessor(bucket, keyPath);
 
       StreamingOutput streamingOutput = output -> {
         try {

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/select/SelectObjectContentRequest.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/select/SelectObjectContentRequest.java
@@ -1,0 +1,388 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.s3.select;
+
+import java.io.InputStream;
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Unmarshaller;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * S3 Select request object for parsing SelectObjectContent requests.
+ */
+@XmlRootElement(name = "SelectObjectContentRequest")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class SelectObjectContentRequest {
+
+  @XmlElement(name = "Expression")
+  private String expression;
+
+  @XmlElement(name = "ExpressionType")
+  private String expressionType;
+
+  @XmlElement(name = "InputSerialization")
+  private InputSerialization inputSerialization;
+
+  @XmlElement(name = "OutputSerialization")
+  private OutputSerialization outputSerialization;
+
+  @XmlElement(name = "ScanRange")
+  private ScanRange scanRange;
+
+  public String getExpression() {
+    return expression;
+  }
+
+  public void setExpression(String expression) {
+    this.expression = expression;
+  }
+
+  public String getExpressionType() {
+    return expressionType;
+  }
+
+  public void setExpressionType(String expressionType) {
+    this.expressionType = expressionType;
+  }
+
+  public InputSerialization getInputSerialization() {
+    return inputSerialization;
+  }
+
+  public void setInputSerialization(InputSerialization inputSerialization) {
+    this.inputSerialization = inputSerialization;
+  }
+
+  public OutputSerialization getOutputSerialization() {
+    return outputSerialization;
+  }
+
+  public void setOutputSerialization(OutputSerialization outputSerialization) {
+    this.outputSerialization = outputSerialization;
+  }
+
+  public ScanRange getScanRange() {
+    return scanRange;
+  }
+
+  public void setScanRange(ScanRange scanRange) {
+    this.scanRange = scanRange;
+  }
+
+  public static SelectObjectContentRequest parseFrom(InputStream inputStream)
+      throws JAXBException {
+    JAXBContext context = JAXBContext.newInstance(SelectObjectContentRequest.class);
+    Unmarshaller unmarshaller = context.createUnmarshaller();
+    return (SelectObjectContentRequest) unmarshaller.unmarshal(inputStream);
+  }
+
+  /**
+   * Input serialization configuration.
+   */
+  @XmlAccessorType(XmlAccessType.FIELD)
+  public static class InputSerialization {
+    @XmlElement(name = "CSV")
+    private CSVInput csv;
+
+    @XmlElement(name = "JSON")
+    private JSONInput json;
+
+    @XmlElement(name = "Parquet")
+    private ParquetInput parquet;
+
+    @XmlElement(name = "CompressionType")
+    private String compressionType;
+
+    public CSVInput getCsv() {
+      return csv;
+    }
+
+    public void setCsv(CSVInput csv) {
+      this.csv = csv;
+    }
+
+    public JSONInput getJson() {
+      return json;
+    }
+
+    public void setJson(JSONInput json) {
+      this.json = json;
+    }
+
+    public ParquetInput getParquet() {
+      return parquet;
+    }
+
+    public void setParquet(ParquetInput parquet) {
+      this.parquet = parquet;
+    }
+
+    public String getCompressionType() {
+      return compressionType;
+    }
+
+    public void setCompressionType(String compressionType) {
+      this.compressionType = compressionType;
+    }
+  }
+
+  /**
+   * Output serialization configuration.
+   */
+  @XmlAccessorType(XmlAccessType.FIELD)
+  public static class OutputSerialization {
+    @XmlElement(name = "CSV")
+    private CSVOutput csv;
+
+    @XmlElement(name = "JSON")
+    private JSONOutput json;
+
+    public CSVOutput getCsv() {
+      return csv;
+    }
+
+    public void setCsv(CSVOutput csv) {
+      this.csv = csv;
+    }
+
+    public JSONOutput getJson() {
+      return json;
+    }
+
+    public void setJson(JSONOutput json) {
+      this.json = json;
+    }
+  }
+
+  /**
+   * CSV input configuration.
+   */
+  @XmlAccessorType(XmlAccessType.FIELD)
+  public static class CSVInput {
+    @XmlElement(name = "FileHeaderInfo")
+    private String fileHeaderInfo;
+
+    @XmlElement(name = "Comments")
+    private String comments;
+
+    @XmlElement(name = "QuoteEscapeCharacter")
+    private String quoteEscapeCharacter;
+
+    @XmlElement(name = "RecordDelimiter")
+    private String recordDelimiter;
+
+    @XmlElement(name = "FieldDelimiter")
+    private String fieldDelimiter;
+
+    @XmlElement(name = "QuoteCharacter")
+    private String quoteCharacter;
+
+    @XmlElement(name = "AllowQuotedRecordDelimiter")
+    private Boolean allowQuotedRecordDelimiter;
+
+    public String getFileHeaderInfo() {
+      return fileHeaderInfo;
+    }
+
+    public void setFileHeaderInfo(String fileHeaderInfo) {
+      this.fileHeaderInfo = fileHeaderInfo;
+    }
+
+    public String getComments() {
+      return comments;
+    }
+
+    public void setComments(String comments) {
+      this.comments = comments;
+    }
+
+    public String getQuoteEscapeCharacter() {
+      return quoteEscapeCharacter;
+    }
+
+    public void setQuoteEscapeCharacter(String quoteEscapeCharacter) {
+      this.quoteEscapeCharacter = quoteEscapeCharacter;
+    }
+
+    public String getRecordDelimiter() {
+      return recordDelimiter;
+    }
+
+    public void setRecordDelimiter(String recordDelimiter) {
+      this.recordDelimiter = recordDelimiter;
+    }
+
+    public String getFieldDelimiter() {
+      return fieldDelimiter;
+    }
+
+    public void setFieldDelimiter(String fieldDelimiter) {
+      this.fieldDelimiter = fieldDelimiter;
+    }
+
+    public String getQuoteCharacter() {
+      return quoteCharacter;
+    }
+
+    public void setQuoteCharacter(String quoteCharacter) {
+      this.quoteCharacter = quoteCharacter;
+    }
+
+    public Boolean getAllowQuotedRecordDelimiter() {
+      return allowQuotedRecordDelimiter;
+    }
+
+    public void setAllowQuotedRecordDelimiter(Boolean allowQuotedRecordDelimiter) {
+      this.allowQuotedRecordDelimiter = allowQuotedRecordDelimiter;
+    }
+  }
+
+  /**
+   * CSV output configuration.
+   */
+  @XmlAccessorType(XmlAccessType.FIELD)
+  public static class CSVOutput {
+    @XmlElement(name = "QuoteFields")
+    private String quoteFields;
+
+    @XmlElement(name = "QuoteEscapeCharacter")
+    private String quoteEscapeCharacter;
+
+    @XmlElement(name = "RecordDelimiter")
+    private String recordDelimiter;
+
+    @XmlElement(name = "FieldDelimiter")
+    private String fieldDelimiter;
+
+    @XmlElement(name = "QuoteCharacter")
+    private String quoteCharacter;
+
+    public String getQuoteFields() {
+      return quoteFields;
+    }
+
+    public void setQuoteFields(String quoteFields) {
+      this.quoteFields = quoteFields;
+    }
+
+    public String getQuoteEscapeCharacter() {
+      return quoteEscapeCharacter;
+    }
+
+    public void setQuoteEscapeCharacter(String quoteEscapeCharacter) {
+      this.quoteEscapeCharacter = quoteEscapeCharacter;
+    }
+
+    public String getRecordDelimiter() {
+      return recordDelimiter;
+    }
+
+    public void setRecordDelimiter(String recordDelimiter) {
+      this.recordDelimiter = recordDelimiter;
+    }
+
+    public String getFieldDelimiter() {
+      return fieldDelimiter;
+    }
+
+    public void setFieldDelimiter(String fieldDelimiter) {
+      this.fieldDelimiter = fieldDelimiter;
+    }
+
+    public String getQuoteCharacter() {
+      return quoteCharacter;
+    }
+
+    public void setQuoteCharacter(String quoteCharacter) {
+      this.quoteCharacter = quoteCharacter;
+    }
+  }
+
+  /**
+   * JSON input configuration.
+   */
+  @XmlAccessorType(XmlAccessType.FIELD)
+  public static class JSONInput {
+    @XmlElement(name = "Type")
+    private String type;
+
+    public String getType() {
+      return type;
+    }
+
+    public void setType(String type) {
+      this.type = type;
+    }
+  }
+
+  /**
+   * JSON output configuration.
+   */
+  @XmlAccessorType(XmlAccessType.FIELD)
+  public static class JSONOutput {
+    @XmlElement(name = "RecordDelimiter")
+    private String recordDelimiter;
+
+    public String getRecordDelimiter() {
+      return recordDelimiter;
+    }
+
+    public void setRecordDelimiter(String recordDelimiter) {
+      this.recordDelimiter = recordDelimiter;
+    }
+  }
+
+  /**
+   * Parquet input configuration.
+   */
+  @XmlAccessorType(XmlAccessType.FIELD)
+  public static class ParquetInput {
+  }
+
+  /**
+   * Scan range configuration for partial object queries.
+   */
+  @XmlAccessorType(XmlAccessType.FIELD)
+  public static class ScanRange {
+    @XmlElement(name = "Start")
+    private Long start;
+
+    @XmlElement(name = "End")
+    private Long end;
+
+    public Long getStart() {
+      return start;
+    }
+
+    public void setStart(Long start) {
+      this.start = start;
+    }
+
+    public Long getEnd() {
+      return end;
+    }
+
+    public void setEnd(Long end) {
+      this.end = end;
+    }
+  }
+}

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/select/SelectObjectContentResponse.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/select/SelectObjectContentResponse.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.s3.select;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.zip.CRC32;
+
+/**
+ * S3 Select response formatter that creates S3-compatible event stream messages.
+ */
+public class SelectObjectContentResponse {
+  private static final byte[] RECORDS_EVENT_TYPE = ":event-type".getBytes(StandardCharsets.UTF_8);
+  private static final byte[] RECORDS_EVENT_NAME = "Records".getBytes(StandardCharsets.UTF_8);
+  private static final byte[] STATS_EVENT_NAME = "Stats".getBytes(StandardCharsets.UTF_8);
+  private static final byte[] END_EVENT_NAME = "End".getBytes(StandardCharsets.UTF_8);
+  private static final byte[] MESSAGE_TYPE = ":message-type".getBytes(StandardCharsets.UTF_8);
+  private static final byte[] EVENT_TYPE = "event".getBytes(StandardCharsets.UTF_8);
+  private static final byte[] CONTENT_TYPE_HEADER = ":content-type".getBytes(StandardCharsets.UTF_8);
+  private static final byte[] OCTET_STREAM = "application/octet-stream".getBytes(StandardCharsets.UTF_8);
+
+  private final OutputStream outputStream;
+
+  public SelectObjectContentResponse(OutputStream outputStream) {
+    this.outputStream = outputStream;
+  }
+
+  public void writeRecordsEvent(RecordsWriter writer) throws IOException {
+    ByteArrayOutputStream payloadStream = new ByteArrayOutputStream();
+    try {
+      writer.write();
+    } catch (Exception e) {
+      throw new IOException("Error writing records", e);
+    }
+    byte[] payload = payloadStream.toByteArray();
+
+    writeEvent(RECORDS_EVENT_NAME, payload);
+  }
+
+  public void writeStatsEvent(long bytesScanned, long bytesProcessed, long bytesReturned) 
+      throws IOException {
+    String statsXml = String.format(
+        "<Stats><BytesScanned>%d</BytesScanned>" +
+        "<BytesProcessed>%d</BytesProcessed>" +
+        "<BytesReturned>%d</BytesReturned></Stats>",
+        bytesScanned, bytesProcessed, bytesReturned);
+    
+    writeEvent(STATS_EVENT_NAME, statsXml.getBytes(StandardCharsets.UTF_8));
+  }
+
+  public void writeEndEvent() throws IOException {
+    writeEvent(END_EVENT_NAME, new byte[0]);
+  }
+
+  private void writeEvent(byte[] eventName, byte[] payload) throws IOException {
+    ByteArrayOutputStream headers = new ByteArrayOutputStream();
+    
+    writeHeader(headers, RECORDS_EVENT_TYPE, eventName);
+    writeHeader(headers, MESSAGE_TYPE, EVENT_TYPE);
+    if (payload.length > 0) {
+      writeHeader(headers, CONTENT_TYPE_HEADER, OCTET_STREAM);
+    }
+
+    byte[] headerBytes = headers.toByteArray();
+    int totalLength = 12 + headerBytes.length + payload.length + 4;
+
+    ByteBuffer prelude = ByteBuffer.allocate(12);
+    prelude.putInt(totalLength);
+    prelude.putInt(headerBytes.length);
+    prelude.putInt(calculateCRC32(prelude.array(), 0, 8));
+
+    outputStream.write(prelude.array());
+    outputStream.write(headerBytes);
+    outputStream.write(payload);
+
+    ByteBuffer messageCrc = ByteBuffer.allocate(4);
+    messageCrc.putInt(calculateCRC32(totalLength, headerBytes, payload));
+    outputStream.write(messageCrc.array());
+
+    outputStream.flush();
+  }
+
+  private void writeHeader(ByteArrayOutputStream stream, byte[] name, byte[] value) 
+      throws IOException {
+    stream.write((byte) name.length);
+    stream.write(name);
+    stream.write((byte) 7);
+    stream.write(ByteBuffer.allocate(2).putShort((short) value.length).array());
+    stream.write(value);
+  }
+
+  private int calculateCRC32(byte[] data, int offset, int length) {
+    CRC32 crc32 = new CRC32();
+    crc32.update(data, offset, length);
+    return (int) crc32.getValue();
+  }
+
+  private int calculateCRC32(int totalLength, byte[] headers, byte[] payload) {
+    CRC32 crc32 = new CRC32();
+    
+    ByteBuffer prelude = ByteBuffer.allocate(8);
+    prelude.putInt(totalLength);
+    prelude.putInt(headers.length);
+    crc32.update(prelude.array());
+    
+    crc32.update(headers);
+    crc32.update(payload);
+    
+    return (int) crc32.getValue();
+  }
+
+  /**
+   * Interface for writing records to the response stream.
+   */
+  public interface RecordsWriter {
+    void write() throws Exception;
+  }
+}

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/select/SelectProcessor.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/select/SelectProcessor.java
@@ -20,10 +20,17 @@ package org.apache.hadoop.ozone.s3.select;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.channels.SeekableByteChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.apache.arrow.datafusion.DataFrame;
 import org.apache.arrow.datafusion.SessionContext;
 import org.apache.arrow.datafusion.SessionContexts;
@@ -32,6 +39,7 @@ import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.ipc.ArrowReader;
 import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.client.OzoneKeyDetails;
 import org.apache.hadoop.ozone.client.io.OzoneInputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -56,9 +64,14 @@ public class SelectProcessor {
     Path tempFile = Files.createTempFile("ozone-select-", ".tmp");
     
     try {
-      downloadObjectToTempFile(tempFile);
-      
-      executeSelectQuery(tempFile, request, output);
+      // For Parquet files, try to optimize the download
+      if (request.getInputSerialization().getParquet() != null) {
+        processParquetWithOptimization(tempFile, request, output);
+      } else {
+        // For CSV/JSON, download the entire file
+        downloadObjectToTempFile(tempFile);
+        executeSelectQuery(tempFile, request, output);
+      }
       
     } finally {
       Files.deleteIfExists(tempFile);
@@ -70,6 +83,149 @@ public class SelectProcessor {
          InputStream inputStream = ozoneInputStream) {
       Files.copy(inputStream, tempFile, StandardCopyOption.REPLACE_EXISTING);
     }
+  }
+
+  private void processParquetWithOptimization(Path tempFile, 
+                                               SelectObjectContentRequest request,
+                                               OutputStream output) throws Exception {
+    // First, download just the Parquet metadata (footer)
+    OzoneKeyDetails keyDetails = bucket.getKey(keyPath);
+    long fileSize = keyDetails.getDataSize();
+    
+    // Parquet footer is typically at the end of file
+    // Start by reading last 8 bytes to get footer size
+    long footerReadStart = Math.max(0, fileSize - 65536); // Read last 64KB for footer
+    
+    Path metadataFile = Files.createTempFile("parquet-meta-", ".tmp");
+    try {
+      // Download the footer portion
+      downloadPartialObject(footerReadStart, fileSize - 1, metadataFile);
+      
+      // Parse the footer to identify row groups and columns
+      ParquetMetadata metadata = readParquetMetadata(metadataFile, fileSize);
+      
+      // Extract predicates and required columns from SQL
+      QueryAnalysis analysis = analyzeQuery(request.getExpression());
+      
+      // Determine which row groups to read based on statistics
+      List<RowGroupRange> rowGroupsToRead = selectRowGroups(metadata, analysis);
+      
+      if (rowGroupsToRead.isEmpty()) {
+        // No matching data, return empty result
+        writeEmptyResult(request, output);
+        return;
+      }
+      
+      // Download only the required row groups
+      downloadRowGroups(rowGroupsToRead, tempFile);
+      
+      // Execute query on the partial file
+      executeSelectQuery(tempFile, request, output);
+      
+    } finally {
+      Files.deleteIfExists(metadataFile);
+    }
+  }
+
+  private void downloadPartialObject(long start, long end, Path targetFile) 
+      throws IOException {
+    // Use range requests to download partial content
+    try (OzoneInputStream ozoneInputStream = bucket.readKey(keyPath);
+         InputStream inputStream = ozoneInputStream;
+         SeekableByteChannel channel = Files.newByteChannel(targetFile, 
+             StandardOpenOption.CREATE, StandardOpenOption.WRITE)) {
+      
+      // Skip to start position
+      long skipped = inputStream.skip(start);
+      if (skipped < start) {
+        throw new IOException("Could not skip to position " + start);
+      }
+      
+      // Read only the requested range
+      long bytesToRead = end - start + 1;
+      byte[] buffer = new byte[8192];
+      long totalRead = 0;
+      
+      while (totalRead < bytesToRead) {
+        int toRead = (int) Math.min(buffer.length, bytesToRead - totalRead);
+        int read = inputStream.read(buffer, 0, toRead);
+        if (read == -1) {
+          break;
+        }
+        channel.write(ByteBuffer.wrap(buffer, 0, read));
+        totalRead += read;
+      }
+    }
+  }
+
+  private ParquetMetadata readParquetMetadata(Path metadataFile, long fileSize) {
+    // Simplified - in reality, we'd parse the Parquet footer
+    // This would use Parquet libraries to read metadata
+    return new ParquetMetadata();
+  }
+
+  private QueryAnalysis analyzeQuery(String sql) {
+    QueryAnalysis analysis = new QueryAnalysis();
+    
+    // Extract SELECT columns
+    Pattern selectPattern = Pattern.compile("SELECT\\s+(.+?)\\s+FROM", Pattern.CASE_INSENSITIVE);
+    Matcher selectMatcher = selectPattern.matcher(sql);
+    if (selectMatcher.find()) {
+      String selectClause = selectMatcher.group(1);
+      if (!selectClause.trim().equals("*")) {
+        analysis.setRequiredColumns(parseColumns(selectClause));
+      }
+    }
+    
+    // Extract WHERE predicates
+    Pattern wherePattern = Pattern.compile("WHERE\\s+(.+?)(?:\\s+ORDER|\\s+GROUP|\\s+LIMIT|$)", 
+                                          Pattern.CASE_INSENSITIVE);
+    Matcher whereMatcher = wherePattern.matcher(sql);
+    if (whereMatcher.find()) {
+      analysis.setPredicates(whereMatcher.group(1));
+    }
+    
+    return analysis;
+  }
+
+  private List<String> parseColumns(String selectClause) {
+    List<String> columns = new ArrayList<>();
+    String[] parts = selectClause.split(",");
+    for (String part : parts) {
+      columns.add(part.trim());
+    }
+    return columns;
+  }
+
+  private List<RowGroupRange> selectRowGroups(ParquetMetadata metadata, 
+                                               QueryAnalysis analysis) {
+    // Use column statistics to filter row groups
+    // This would check min/max values against predicates
+    List<RowGroupRange> ranges = new ArrayList<>();
+    // Simplified implementation
+    ranges.add(new RowGroupRange(0, metadata.getFileSize()));
+    return ranges;
+  }
+
+  private void downloadRowGroups(List<RowGroupRange> rowGroups, Path targetFile) 
+      throws IOException {
+    try (SeekableByteChannel channel = Files.newByteChannel(targetFile,
+             StandardOpenOption.CREATE, StandardOpenOption.WRITE)) {
+      
+      for (RowGroupRange range : rowGroups) {
+        downloadPartialObject(range.getStart(), range.getEnd(), targetFile);
+      }
+    }
+  }
+
+  private void writeEmptyResult(SelectObjectContentRequest request, 
+                                OutputStream output) throws IOException {
+    SelectObjectContentResponse response = new SelectObjectContentResponse(output);
+    response.writeRecordsEvent(() -> {
+      // Write empty result
+    });
+    response.writeStatsEvent(0, 0, 0);
+    response.writeEndEvent();
   }
 
   private void executeSelectQuery(Path dataFile, SelectObjectContentRequest request, 
@@ -198,6 +354,66 @@ public class SelectProcessor {
       }
       jsonBuilder.append('}').append(recordDelimiter);
       output.write(jsonBuilder.toString().getBytes());
+    }
+  }
+
+  /**
+   * Helper class to store Parquet metadata.
+   */
+  private static class ParquetMetadata {
+    private long fileSize;
+    
+    public long getFileSize() {
+      return fileSize;
+    }
+    
+    public void setFileSize(long fileSize) {
+      this.fileSize = fileSize;
+    }
+  }
+
+  /**
+   * Helper class to store query analysis results.
+   */
+  private static class QueryAnalysis {
+    private List<String> requiredColumns;
+    private String predicates;
+    
+    public List<String> getRequiredColumns() {
+      return requiredColumns;
+    }
+    
+    public void setRequiredColumns(List<String> columns) {
+      this.requiredColumns = columns;
+    }
+    
+    public String getPredicates() {
+      return predicates;
+    }
+    
+    public void setPredicates(String predicates) {
+      this.predicates = predicates;
+    }
+  }
+
+  /**
+   * Helper class to store row group byte ranges.
+   */
+  private static class RowGroupRange {
+    private final long start;
+    private final long end;
+    
+    RowGroupRange(long start, long end) {
+      this.start = start;
+      this.end = end;
+    }
+    
+    public long getStart() {
+      return start;
+    }
+    
+    public long getEnd() {
+      return end;
     }
   }
 }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/select/SelectProcessor.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/select/SelectProcessor.java
@@ -1,0 +1,205 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.s3.select;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.concurrent.CompletableFuture;
+import org.apache.arrow.datafusion.DataFrame;
+import org.apache.arrow.datafusion.SessionContext;
+import org.apache.arrow.datafusion.SessionContexts;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.ipc.ArrowReader;
+import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.client.OzoneClient;
+import org.apache.hadoop.ozone.client.io.OzoneInputStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Processor for S3 Select queries using DataFusion.
+ */
+public class SelectProcessor {
+  private static final Logger LOG = LoggerFactory.getLogger(SelectProcessor.class);
+  
+  private final OzoneClient client;
+  private final OzoneBucket bucket;
+  private final String keyPath;
+
+  public SelectProcessor(OzoneClient client, OzoneBucket bucket, String keyPath) {
+    this.client = client;
+    this.bucket = bucket;
+    this.keyPath = keyPath;
+  }
+
+  public void processSelect(SelectObjectContentRequest request, OutputStream output) 
+      throws Exception {
+    
+    Path tempFile = Files.createTempFile("ozone-select-", ".tmp");
+    
+    try {
+      downloadObjectToTempFile(tempFile);
+      
+      executeSelectQuery(tempFile, request, output);
+      
+    } finally {
+      Files.deleteIfExists(tempFile);
+    }
+  }
+
+  private void downloadObjectToTempFile(Path tempFile) throws IOException {
+    try (OzoneInputStream ozoneInputStream = bucket.readKey(keyPath);
+         InputStream inputStream = ozoneInputStream) {
+      Files.copy(inputStream, tempFile, StandardCopyOption.REPLACE_EXISTING);
+    }
+  }
+
+  private void executeSelectQuery(Path dataFile, SelectObjectContentRequest request, 
+                                   OutputStream output) throws Exception {
+    
+    try (SessionContext context = SessionContexts.create();
+         BufferAllocator allocator = new RootAllocator()) {
+      
+      String tableName = registerTable(context, dataFile, request);
+      
+      String sqlQuery = convertS3SelectToSQL(request.getExpression(), tableName);
+      
+      CompletableFuture<DataFrame> dataFrameFuture = context.sql(sqlQuery);
+      DataFrame dataFrame = dataFrameFuture.join();
+      
+      writeResultsToOutput(dataFrame, allocator, request, output);
+    }
+  }
+
+  private String registerTable(SessionContext context, Path dataFile, 
+                               SelectObjectContentRequest request) throws Exception {
+    String tableName = "s3_select_table";
+    
+    if (request.getInputSerialization().getCsv() != null) {
+      context.registerCsv(tableName, dataFile).join();
+    } else if (request.getInputSerialization().getJson() != null) {
+      // For JSON, we'll use CSV reader with specific settings
+      // DataFusion Java doesn't have registerJson yet, so we'll treat it as CSV for now
+      context.registerCsv(tableName, dataFile).join();
+    } else if (request.getInputSerialization().getParquet() != null) {
+      context.registerParquet(tableName, dataFile).join();
+    } else {
+      throw new IllegalArgumentException("Unsupported input serialization format");
+    }
+    
+    return tableName;
+  }
+
+  private String convertS3SelectToSQL(String s3SelectExpression, String tableName) {
+    String sql = s3SelectExpression;
+    
+    sql = sql.replaceAll("(?i)FROM\\s+S3Object", "FROM " + tableName);
+    sql = sql.replaceAll("(?i)S3Object\\.", tableName + ".");
+    
+    sql = sql.replaceAll("(?i)_\\d+", "column$0");
+    
+    return sql;
+  }
+
+  private void writeResultsToOutput(DataFrame dataFrame, BufferAllocator allocator,
+                                    SelectObjectContentRequest request, 
+                                    OutputStream output) throws Exception {
+    
+    SelectObjectContentResponse response = new SelectObjectContentResponse(output);
+    
+    response.writeRecordsEvent(() -> {
+      try (ArrowReader reader = dataFrame.collect(allocator).join()) {
+        VectorSchemaRoot root = reader.getVectorSchemaRoot();
+        
+        while (reader.loadNextBatch()) {
+          if (request.getOutputSerialization().getCsv() != null) {
+            writeCSVOutput(root, request.getOutputSerialization().getCsv(), output);
+          } else if (request.getOutputSerialization().getJson() != null) {
+            writeJSONOutput(root, request.getOutputSerialization().getJson(), output);
+          }
+        }
+      } catch (Exception e) {
+        LOG.error("Error writing results", e);
+        throw new RuntimeException(e);
+      }
+    });
+    
+    response.writeStatsEvent(0, 0, 0);
+    
+    response.writeEndEvent();
+  }
+
+  private void writeCSVOutput(VectorSchemaRoot root, 
+                              SelectObjectContentRequest.CSVOutput csvOutput,
+                              OutputStream output) throws IOException {
+    String delimiter = csvOutput.getFieldDelimiter() != null ? 
+        csvOutput.getFieldDelimiter() : ",";
+    String recordDelimiter = csvOutput.getRecordDelimiter() != null ? 
+        csvOutput.getRecordDelimiter() : "\n";
+    
+    for (int row = 0; row < root.getRowCount(); row++) {
+      StringBuilder rowBuilder = new StringBuilder();
+      for (int col = 0; col < root.getFieldVectors().size(); col++) {
+        if (col > 0) {
+          rowBuilder.append(delimiter);
+        }
+        Object value = root.getFieldVectors().get(col).getObject(row);
+        if (value != null) {
+          rowBuilder.append(value.toString());
+        }
+      }
+      rowBuilder.append(recordDelimiter);
+      output.write(rowBuilder.toString().getBytes());
+    }
+  }
+
+  private void writeJSONOutput(VectorSchemaRoot root,
+                               SelectObjectContentRequest.JSONOutput jsonOutput,
+                               OutputStream output) throws IOException {
+    String recordDelimiter = jsonOutput.getRecordDelimiter() != null ?
+        jsonOutput.getRecordDelimiter() : "\n";
+    
+    for (int row = 0; row < root.getRowCount(); row++) {
+      StringBuilder jsonBuilder = new StringBuilder("{");
+      for (int col = 0; col < root.getFieldVectors().size(); col++) {
+        if (col > 0) {
+          jsonBuilder.append(",");
+        }
+        String fieldName = root.getSchema().getFields().get(col).getName();
+        Object value = root.getFieldVectors().get(col).getObject(row);
+        
+        jsonBuilder.append("\"").append(fieldName).append("\":");
+        if (value == null) {
+          jsonBuilder.append("null");
+        } else if (value instanceof String) {
+          jsonBuilder.append("\"").append(value).append("\"");
+        } else {
+          jsonBuilder.append(value);
+        }
+      }
+      jsonBuilder.append("}").append(recordDelimiter);
+      output.write(jsonBuilder.toString().getBytes());
+    }
+  }
+}

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/select/package-info.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/select/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * S3 Select implementation for Apache Ozone.
+ * This package contains classes for processing S3 Select queries
+ * using Apache DataFusion as the query engine.
+ */
+package org.apache.hadoop.ozone.s3.select;

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestSelectObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestSelectObjectEndpoint.java
@@ -1,0 +1,213 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.s3.endpoint;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import javax.ws.rs.core.Response;
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.Marshaller;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.client.ObjectStore;
+import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.client.OzoneClientStub;
+import org.apache.hadoop.ozone.s3.select.SelectObjectContentRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test S3 Select functionality.
+ */
+public class TestSelectObjectEndpoint {
+
+  private OzoneClientStub clientStub;
+  private ObjectStore objectStore;
+  private ObjectEndpoint objectEndpoint;
+  private OzoneBucket bucket;
+
+  @BeforeEach
+  public void setup() throws Exception {
+    OzoneConfiguration config = new OzoneConfiguration();
+    clientStub = new OzoneClientStub();
+    objectStore = clientStub.getObjectStore();
+    
+    objectEndpoint = new ObjectEndpoint();
+    objectEndpoint.setClient(clientStub);
+    objectEndpoint.setOzoneConfiguration(config);
+    objectEndpoint.init();
+
+    String bucketName = "bucket1";
+    objectStore.createS3Bucket(bucketName);
+    bucket = objectStore.getS3Bucket(bucketName);
+  }
+
+  @Test
+  public void testSelectObjectWithNullParameters() throws Exception {
+    // Test that when select parameters are null, the endpoint returns null
+    Response response = objectEndpoint.selectObjectContent(
+        "bucket1", "key1", null, null, null);
+    assertNull(response);
+  }
+
+  @Test
+  public void testSelectObjectWithInvalidSelectType() throws Exception {
+    // Test that when select-type is not "2", the endpoint returns null
+    Response response = objectEndpoint.selectObjectContent(
+        "bucket1", "key1", "present", "1", null);
+    assertNull(response);
+  }
+
+  @Test
+  public void testSelectCSVRequest() throws Exception {
+    // Create test CSV data
+    String csvData = "name,age,city\n" +
+                    "John,30,NYC\n" +
+                    "Jane,25,LA\n" +
+                    "Bob,35,Chicago\n";
+    
+    bucket.createKey("test.csv", csvData.length()).write(csvData.getBytes());
+
+    // Create S3 Select request
+    SelectObjectContentRequest request = createCSVSelectRequest(
+        "SELECT * FROM S3Object WHERE age > 25");
+
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    JAXBContext context = JAXBContext.newInstance(SelectObjectContentRequest.class);
+    Marshaller marshaller = context.createMarshaller();
+    marshaller.marshal(request, baos);
+    
+    InputStream requestBody = new ByteArrayInputStream(baos.toByteArray());
+
+    Response response = objectEndpoint.selectObjectContent(
+        "bucket1", "test.csv", "present", "2", requestBody);
+    
+    assertNotNull(response);
+    assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+  }
+
+  @Test
+  public void testSelectParquetRequest() throws Exception {
+    // Create test key (Parquet testing would need actual Parquet data)
+    bucket.createKey("test.parquet", 100).write(new byte[100]);
+
+    SelectObjectContentRequest request = createParquetSelectRequest(
+        "SELECT * FROM S3Object LIMIT 10");
+
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    JAXBContext context = JAXBContext.newInstance(SelectObjectContentRequest.class);
+    Marshaller marshaller = context.createMarshaller();
+    marshaller.marshal(request, baos);
+    
+    InputStream requestBody = new ByteArrayInputStream(baos.toByteArray());
+
+    Response response = objectEndpoint.selectObjectContent(
+        "bucket1", "test.parquet", "present", "2", requestBody);
+    
+    assertNotNull(response);
+    assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+  }
+
+  @Test
+  public void testSelectWithScanRange() throws Exception {
+    String csvData = "name,age,city\n" +
+                    "John,30,NYC\n" +
+                    "Jane,25,LA\n" +
+                    "Bob,35,Chicago\n";
+    
+    bucket.createKey("rangetest.csv", csvData.length()).write(csvData.getBytes());
+
+    SelectObjectContentRequest request = createCSVSelectRequest(
+        "SELECT * FROM S3Object");
+    
+    // Add scan range
+    SelectObjectContentRequest.ScanRange scanRange = 
+        new SelectObjectContentRequest.ScanRange();
+    scanRange.setStart(0L);
+    scanRange.setEnd(50L);
+    request.setScanRange(scanRange);
+
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    JAXBContext context = JAXBContext.newInstance(SelectObjectContentRequest.class);
+    Marshaller marshaller = context.createMarshaller();
+    marshaller.marshal(request, baos);
+    
+    InputStream requestBody = new ByteArrayInputStream(baos.toByteArray());
+
+    Response response = objectEndpoint.selectObjectContent(
+        "bucket1", "rangetest.csv", "present", "2", requestBody);
+    
+    assertNotNull(response);
+    assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+  }
+
+  private SelectObjectContentRequest createCSVSelectRequest(String expression) {
+    SelectObjectContentRequest request = new SelectObjectContentRequest();
+    request.setExpression(expression);
+    request.setExpressionType("SQL");
+    
+    SelectObjectContentRequest.InputSerialization input = 
+        new SelectObjectContentRequest.InputSerialization();
+    SelectObjectContentRequest.CSVInput csvInput = 
+        new SelectObjectContentRequest.CSVInput();
+    csvInput.setFileHeaderInfo("USE");
+    csvInput.setFieldDelimiter(",");
+    csvInput.setRecordDelimiter("\n");
+    input.setCsv(csvInput);
+    request.setInputSerialization(input);
+    
+    SelectObjectContentRequest.OutputSerialization output = 
+        new SelectObjectContentRequest.OutputSerialization();
+    SelectObjectContentRequest.CSVOutput csvOutput = 
+        new SelectObjectContentRequest.CSVOutput();
+    csvOutput.setFieldDelimiter(",");
+    csvOutput.setRecordDelimiter("\n");
+    output.setCsv(csvOutput);
+    request.setOutputSerialization(output);
+    
+    return request;
+  }
+
+  private SelectObjectContentRequest createParquetSelectRequest(String expression) {
+    SelectObjectContentRequest request = new SelectObjectContentRequest();
+    request.setExpression(expression);
+    request.setExpressionType("SQL");
+    
+    SelectObjectContentRequest.InputSerialization input = 
+        new SelectObjectContentRequest.InputSerialization();
+    SelectObjectContentRequest.ParquetInput parquetInput = 
+        new SelectObjectContentRequest.ParquetInput();
+    input.setParquet(parquetInput);
+    request.setInputSerialization(input);
+    
+    SelectObjectContentRequest.OutputSerialization output = 
+        new SelectObjectContentRequest.OutputSerialization();
+    SelectObjectContentRequest.CSVOutput csvOutput = 
+        new SelectObjectContentRequest.CSVOutput();
+    csvOutput.setFieldDelimiter(",");
+    csvOutput.setRecordDelimiter("\n");
+    output.setCsv(csvOutput);
+    request.setOutputSerialization(output);
+    
+    return request;
+  }
+}

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/select/TestSelectObjectContentRequest.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/select/TestSelectObjectContentRequest.java
@@ -1,0 +1,184 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.s3.select;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import javax.xml.bind.JAXBException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test S3 Select request parsing.
+ */
+public class TestSelectObjectContentRequest {
+
+  @Test
+  public void testParseCSVSelectRequest() throws JAXBException {
+    String xmlRequest = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+        "<SelectObjectContentRequest>" +
+        "  <Expression>SELECT * FROM S3Object WHERE age > 25</Expression>" +
+        "  <ExpressionType>SQL</ExpressionType>" +
+        "  <InputSerialization>" +
+        "    <CSV>" +
+        "      <FileHeaderInfo>USE</FileHeaderInfo>" +
+        "      <FieldDelimiter>,</FieldDelimiter>" +
+        "      <RecordDelimiter>\\n</RecordDelimiter>" +
+        "    </CSV>" +
+        "  </InputSerialization>" +
+        "  <OutputSerialization>" +
+        "    <CSV>" +
+        "      <FieldDelimiter>,</FieldDelimiter>" +
+        "      <RecordDelimiter>\\n</RecordDelimiter>" +
+        "    </CSV>" +
+        "  </OutputSerialization>" +
+        "</SelectObjectContentRequest>";
+
+    InputStream inputStream = new ByteArrayInputStream(xmlRequest.getBytes());
+    SelectObjectContentRequest request = 
+        SelectObjectContentRequest.parseFrom(inputStream);
+
+    assertNotNull(request);
+    assertEquals("SELECT * FROM S3Object WHERE age > 25", request.getExpression());
+    assertEquals("SQL", request.getExpressionType());
+    assertNotNull(request.getInputSerialization());
+    assertNotNull(request.getInputSerialization().getCsv());
+    assertEquals("USE", request.getInputSerialization().getCsv().getFileHeaderInfo());
+    assertEquals(",", request.getInputSerialization().getCsv().getFieldDelimiter());
+    assertNotNull(request.getOutputSerialization());
+    assertNotNull(request.getOutputSerialization().getCsv());
+    assertEquals(",", request.getOutputSerialization().getCsv().getFieldDelimiter());
+  }
+
+  @Test
+  public void testParseJSONSelectRequest() throws JAXBException {
+    String xmlRequest = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+        "<SelectObjectContentRequest>" +
+        "  <Expression>SELECT * FROM S3Object[*] s WHERE s.age > 25</Expression>" +
+        "  <ExpressionType>SQL</ExpressionType>" +
+        "  <InputSerialization>" +
+        "    <JSON>" +
+        "      <Type>LINES</Type>" +
+        "    </JSON>" +
+        "  </InputSerialization>" +
+        "  <OutputSerialization>" +
+        "    <JSON>" +
+        "      <RecordDelimiter>\\n</RecordDelimiter>" +
+        "    </JSON>" +
+        "  </OutputSerialization>" +
+        "</SelectObjectContentRequest>";
+
+    InputStream inputStream = new ByteArrayInputStream(xmlRequest.getBytes());
+    SelectObjectContentRequest request = 
+        SelectObjectContentRequest.parseFrom(inputStream);
+
+    assertNotNull(request);
+    assertEquals("SELECT * FROM S3Object[*] s WHERE s.age > 25", 
+        request.getExpression());
+    assertEquals("SQL", request.getExpressionType());
+    assertNotNull(request.getInputSerialization());
+    assertNotNull(request.getInputSerialization().getJson());
+    assertEquals("LINES", request.getInputSerialization().getJson().getType());
+    assertNotNull(request.getOutputSerialization());
+    assertNotNull(request.getOutputSerialization().getJson());
+  }
+
+  @Test
+  public void testParseParquetSelectRequest() throws JAXBException {
+    String xmlRequest = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+        "<SelectObjectContentRequest>" +
+        "  <Expression>SELECT * FROM S3Object LIMIT 10</Expression>" +
+        "  <ExpressionType>SQL</ExpressionType>" +
+        "  <InputSerialization>" +
+        "    <Parquet/>" +
+        "  </InputSerialization>" +
+        "  <OutputSerialization>" +
+        "    <CSV>" +
+        "      <FieldDelimiter>,</FieldDelimiter>" +
+        "    </CSV>" +
+        "  </OutputSerialization>" +
+        "</SelectObjectContentRequest>";
+
+    InputStream inputStream = new ByteArrayInputStream(xmlRequest.getBytes());
+    SelectObjectContentRequest request = 
+        SelectObjectContentRequest.parseFrom(inputStream);
+
+    assertNotNull(request);
+    assertEquals("SELECT * FROM S3Object LIMIT 10", request.getExpression());
+    assertNotNull(request.getInputSerialization());
+    assertNotNull(request.getInputSerialization().getParquet());
+    assertNull(request.getInputSerialization().getCsv());
+    assertNull(request.getInputSerialization().getJson());
+  }
+
+  @Test
+  public void testParseSelectRequestWithScanRange() throws JAXBException {
+    String xmlRequest = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+        "<SelectObjectContentRequest>" +
+        "  <Expression>SELECT * FROM S3Object</Expression>" +
+        "  <ExpressionType>SQL</ExpressionType>" +
+        "  <InputSerialization>" +
+        "    <CSV/>" +
+        "  </InputSerialization>" +
+        "  <OutputSerialization>" +
+        "    <CSV/>" +
+        "  </OutputSerialization>" +
+        "  <ScanRange>" +
+        "    <Start>50</Start>" +
+        "    <End>1000</End>" +
+        "  </ScanRange>" +
+        "</SelectObjectContentRequest>";
+
+    InputStream inputStream = new ByteArrayInputStream(xmlRequest.getBytes());
+    SelectObjectContentRequest request = 
+        SelectObjectContentRequest.parseFrom(inputStream);
+
+    assertNotNull(request);
+    assertNotNull(request.getScanRange());
+    assertEquals(Long.valueOf(50), request.getScanRange().getStart());
+    assertEquals(Long.valueOf(1000), request.getScanRange().getEnd());
+  }
+
+  @Test
+  public void testParseSelectRequestWithCompressionType() throws JAXBException {
+    String xmlRequest = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+        "<SelectObjectContentRequest>" +
+        "  <Expression>SELECT * FROM S3Object</Expression>" +
+        "  <ExpressionType>SQL</ExpressionType>" +
+        "  <InputSerialization>" +
+        "    <CompressionType>GZIP</CompressionType>" +
+        "    <CSV/>" +
+        "  </InputSerialization>" +
+        "  <OutputSerialization>" +
+        "    <CSV/>" +
+        "  </OutputSerialization>" +
+        "</SelectObjectContentRequest>";
+
+    InputStream inputStream = new ByteArrayInputStream(xmlRequest.getBytes());
+    SelectObjectContentRequest request = 
+        SelectObjectContentRequest.parseFrom(inputStream);
+
+    assertNotNull(request);
+    assertNotNull(request.getInputSerialization());
+    assertEquals("GZIP", request.getInputSerialization().getCompressionType());
+  }
+}
+


### PR DESCRIPTION
- Added support for S3 Select queries using Apache DataFusion as the query engine.
- Introduced new classes for handling SelectObjectContent requests and responses.
- Updated ObjectEndpoint to process S3 Select requests and return results in CSV or JSON format.
- Added unit tests to validate S3 Select functionality for CSV and Parquet data formats.
- Included necessary dependencies in pom.xml for DataFusion integration.
