### PR TITLE
HDDS-12632. Support BlockLocation.topologyPaths for FileStatus/LocatedFileStatus/BlockLocation

### DIFF
--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
@@ -615,6 +615,7 @@ public class BasicOzoneClientAdapterImpl implements OzoneClientAdapter {
         omKeyLocationInfoGroup.getBlocksLatestVersionOnly()) {
       List<String> hostList = new ArrayList<>();
       List<String> nameList = new ArrayList<>();
+      List<String> topologyPathList = new ArrayList<>();
       omKeyLocationInfo.getPipeline().getNodes()
           .forEach(dn -> {
             hostList.add(dn.getHostName());
@@ -623,12 +624,14 @@ public class BasicOzoneClientAdapterImpl implements OzoneClientAdapter {
               port = configuredDnPort;
             }
             nameList.add(dn.getHostName() + ":" + port);
+            topologyPathList.add(dn.getNetworkLocation());
           });
 
       String[] hosts = hostList.toArray(new String[0]);
       String[] names = nameList.toArray(new String[0]);
+      String[] topologyPaths = topologyPathList.toArray(new String[0]);
       BlockLocation blockLocation = new BlockLocation(
-          names, hosts, offsetOfBlockInFile,
+          names, hosts, topologyPaths, offsetOfBlockInFile,
           omKeyLocationInfo.getLength());
       offsetOfBlockInFile += omKeyLocationInfo.getLength();
       blockLocations[i++] = blockLocation;

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -1112,6 +1112,7 @@ public class BasicRootedOzoneClientAdapterImpl
         omKeyLocationInfoGroup.getBlocksLatestVersionOnly()) {
       List<String> hostList = new ArrayList<>();
       List<String> nameList = new ArrayList<>();
+      List<String> topologyPathList = new ArrayList<>();
       omKeyLocationInfo.getPipeline().getNodes()
           .forEach(dn -> {
             hostList.add(dn.getHostName());
@@ -1120,12 +1121,14 @@ public class BasicRootedOzoneClientAdapterImpl
               port = configuredDnPort;
             }
             nameList.add(dn.getHostName() + ":" + port);
+            topologyPathList.add(dn.getNetworkLocation());
           });
 
       String[] hosts = hostList.toArray(new String[0]);
       String[] names = nameList.toArray(new String[0]);
+      String[] topologyPaths = topologyPathList.toArray(new String[0]);
       BlockLocation blockLocation = new BlockLocation(
-          names, hosts, offsetOfBlockInFile,
+          names, hosts, topologyPaths, offsetOfBlockInFile,
           omKeyLocationInfo.getLength());
       offsetOfBlockInFile += omKeyLocationInfo.getLength();
       blockLocations[i++] = blockLocation;


### PR DESCRIPTION
## What changes were proposed in this pull request?

xxx

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12632

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests, workflow run on the fork git repo.)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this.)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Populate BlockLocation.topologyPaths in Ozone FS adapters and add tests verifying topology info for single- and multi-block files.
> 
> - **Adapters (ozonefs-common)**:
>   - `BasicOzoneClientAdapterImpl#getBlockLocations` and `BasicRootedOzoneClientAdapterImpl#getBlockLocations` now collect datanode `networkLocation` and construct `BlockLocation` with `names`, `hosts`, and `topologyPaths`.
> - **Tests (integration-test)**:
>   - Add topology path assertions in `AbstractOzoneFileSystemTest` and `AbstractRootedOzoneFileSystemTest`:
>     - Validate `BlockLocation.getTopologyPaths()` is non-null, has entries, and matches lengths of `hosts`/`names`.
>     - Cover single- and multi-block files to ensure topology info is present across all blocks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 327d8859903032827377e72a692af75f4b827556. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->