### PR TITLE
local standalone ozone

### DIFF
--- a/hadoop-ozone/dist/src/shell/ozone/ozone
+++ b/hadoop-ozone/dist/src/shell/ozone/ozone
@@ -57,6 +57,7 @@ function ozone_usage
   ozone_add_subcommand "s3" client "command line interface for s3 related operations"
   ozone_add_subcommand "tenant" client "command line interface for multi-tenant related operations"
   ozone_add_subcommand "insight" client "tool to get runtime operation information"
+  ozone_add_subcommand "local" client "run a single-node local ozone cluster"
   ozone_add_subcommand "version" client "print the version"
   ozone_add_subcommand "dtutil" client "operations related to delegation tokens"
   ozone_add_subcommand "admin" client "Ozone admin tool"
@@ -208,6 +209,10 @@ function ozonecmd_case
     insight)
       OZONE_CLASSNAME=org.apache.hadoop.ozone.insight.Insight
       OZONE_RUN_ARTIFACT_NAME="ozone-insight"
+    ;;
+    local)
+      OZONE_CLASSNAME=org.apache.hadoop.ozone.local.OzoneLocal
+      OZONE_RUN_ARTIFACT_NAME="ozone-tools"
     ;;
     version)
       OZONE_CLASSNAME=org.apache.hadoop.ozone.util.OzoneVersionInfo

--- a/hadoop-ozone/tools/pom.xml
+++ b/hadoop-ozone/tools/pom.xml
@@ -64,7 +64,23 @@
     </dependency>
     <dependency>
       <groupId>org.apache.ozone</groupId>
+      <artifactId>hdds-container-service</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
+      <artifactId>hdds-server-scm</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
       <artifactId>ozone-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
+      <artifactId>ozone-manager</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
+      <artifactId>ozone-s3gateway</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.ratis</groupId>

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/local/LocalOzoneCluster.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/local/LocalOzoneCluster.java
@@ -1,0 +1,520 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.local;
+
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_DATANODE_CLIENT_ADDRESS_KEY;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_DATANODE_CLIENT_BIND_HOST_KEY;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_DATANODE_HTTP_ADDRESS_KEY;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_DATANODE_HTTP_BIND_HOST_KEY;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_INITIAL_HEARTBEAT_INTERVAL;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_RECON_INITIAL_HEARTBEAT_INTERVAL;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_SCM_SAFEMODE_MIN_DATANODE;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_SCM_SAFEMODE_PIPELINE_CREATION;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeState.HEALTHY;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_CONTAINER_RATIS_ENABLED_KEY;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_DATANODE_DIR_KEY;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_BLOCK_CLIENT_ADDRESS_KEY;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_BLOCK_CLIENT_BIND_HOST_KEY;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CLIENT_ADDRESS_KEY;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CLIENT_BIND_HOST_KEY;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_DATANODE_ADDRESS_KEY;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_DATANODE_BIND_HOST_KEY;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_GRPC_PORT_KEY;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HA_RATIS_SERVER_RPC_FIRST_ELECTION_TIMEOUT;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HTTP_ADDRESS_KEY;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HTTP_BIND_HOST_KEY;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_NAMES;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_RATIS_PORT_KEY;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_SECURITY_SERVICE_ADDRESS_KEY;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_SECURITY_SERVICE_BIND_HOST_KEY;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.HDDS_CONTAINER_IPC_PORT;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.HDDS_CONTAINER_RATIS_ADMIN_PORT;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.HDDS_CONTAINER_RATIS_DATASTREAM_PORT;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.HDDS_CONTAINER_RATIS_DATANODE_STORAGE_DIR;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.HDDS_CONTAINER_RATIS_IPC_PORT;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.HDDS_CONTAINER_RATIS_SERVER_PORT;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.HDDS_RATIS_LEADER_FIRST_ELECTION_MINIMUM_TIMEOUT_DURATION_KEY;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_METADATA_DIRS;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_REPLICATION;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_REPLICATION_TYPE;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_HTTP_ADDRESS_KEY;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_HTTP_BIND_HOST_KEY;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_HTTPS_ADDRESS_KEY;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_HTTPS_BIND_HOST_KEY;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_RATIS_MINIMUM_TIMEOUT_KEY;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_RATIS_PORT_KEY;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_SERVER_DEFAULT_REPLICATION_KEY;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_SERVER_DEFAULT_REPLICATION_TYPE_KEY;
+import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_HTTP_ADDRESS_KEY;
+import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_HTTP_BIND_HOST_KEY;
+import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_HTTPS_ADDRESS_KEY;
+import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_HTTPS_BIND_HOST_KEY;
+import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_WEBADMIN_HTTP_ADDRESS_KEY;
+import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_WEBADMIN_HTTP_BIND_HOST_KEY;
+import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_WEBADMIN_HTTPS_ADDRESS_KEY;
+import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_WEBADMIN_HTTPS_BIND_HOST_KEY;
+import static org.apache.hadoop.ozone.common.Storage.StorageState.INITIALIZED;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.commons.io.FileUtils;
+import org.apache.hadoop.hdds.HddsConfigKeys;
+import org.apache.hadoop.hdds.client.ReplicationFactor;
+import org.apache.hadoop.hdds.client.ReplicationType;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.scm.ScmConfigKeys;
+import org.apache.hadoop.hdds.scm.proxy.SCMClientConfig;
+import org.apache.hadoop.hdds.scm.ha.SCMHANodeDetails;
+import org.apache.hadoop.hdds.scm.ha.SCMRatisServerImpl;
+import org.apache.hadoop.hdds.scm.server.SCMStorageConfig;
+import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
+import org.apache.hadoop.ozone.HddsDatanodeService;
+import org.apache.hadoop.ozone.OzoneSecurityUtil;
+import org.apache.hadoop.ozone.container.replication.ReplicationServer;
+import org.apache.hadoop.ozone.local.LocalOzoneClusterConfig.FormatMode;
+import org.apache.hadoop.ozone.om.OMStorage;
+import org.apache.hadoop.ozone.om.OzoneManager;
+import org.apache.hadoop.ozone.s3.Gateway;
+import org.apache.hadoop.ozone.s3.OzoneConfigurationHolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Starts a small in-process local Ozone cluster.
+ */
+public final class LocalOzoneCluster implements AutoCloseable {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(LocalOzoneCluster.class);
+
+  private static final String[] NO_ARGS = new String[0];
+
+  private final LocalOzoneClusterConfig config;
+  private final OzoneConfiguration seedConfiguration;
+  private final AtomicBoolean closed = new AtomicBoolean();
+  private final List<HddsDatanodeService> datanodes = new ArrayList<>();
+
+  private PreparedConfiguration preparedConfiguration;
+  private StorageContainerManager scm;
+  private OzoneManager om;
+  private Gateway s3Gateway;
+
+  public LocalOzoneCluster(LocalOzoneClusterConfig config,
+      OzoneConfiguration seedConfiguration) {
+    this.config = Objects.requireNonNull(config, "config");
+    this.seedConfiguration = new OzoneConfiguration(
+        Objects.requireNonNull(seedConfiguration, "seedConfiguration"));
+  }
+
+  public void start() throws Exception {
+    preparedConfiguration = prepareConfiguration();
+    initializeStorage(preparedConfiguration.getConfiguration());
+
+    scm = StorageContainerManager.createSCM(preparedConfiguration.getConfiguration());
+    scm.start();
+
+    om = OzoneManager.createOm(preparedConfiguration.getConfiguration());
+    om.start();
+
+    startDatanodes(preparedConfiguration.getConfiguration());
+
+    if (config.isS3gEnabled()) {
+      startS3Gateway(preparedConfiguration.getConfiguration());
+    }
+
+    waitForClusterToBeReady(config.getStartupTimeout());
+  }
+
+  PreparedConfiguration prepareConfiguration() throws IOException {
+    if (preparedConfiguration != null) {
+      return preparedConfiguration;
+    }
+
+    if (config.getFormatMode() == FormatMode.ALWAYS) {
+      FileUtils.deleteQuietly(config.getDataDir().toFile());
+    }
+    Files.createDirectories(config.getDataDir());
+
+    OzoneConfiguration conf = new OzoneConfiguration(seedConfiguration);
+    conf.set(OZONE_METADATA_DIRS, createDirectory("metadata").toString());
+    conf.set(OZONE_REPLICATION, ReplicationFactor.ONE.name());
+    conf.set(OZONE_REPLICATION_TYPE, ReplicationType.STAND_ALONE.name());
+    conf.set(OZONE_SERVER_DEFAULT_REPLICATION_KEY, ReplicationFactor.ONE.name());
+    conf.set(OZONE_SERVER_DEFAULT_REPLICATION_TYPE_KEY,
+        ReplicationType.STAND_ALONE.name());
+    conf.setBoolean(HDDS_CONTAINER_RATIS_ENABLED_KEY, false);
+    conf.setBoolean(HDDS_SCM_SAFEMODE_PIPELINE_CREATION, false);
+    conf.setInt(HDDS_SCM_SAFEMODE_MIN_DATANODE, Math.max(1, config.getDatanodes()));
+    conf.set(HddsConfigKeys.HDDS_SCM_WAIT_TIME_AFTER_SAFE_MODE_EXIT, "3s");
+    conf.set(OZONE_SCM_HA_RATIS_SERVER_RPC_FIRST_ELECTION_TIMEOUT, "1s");
+    conf.setTimeDuration(OZONE_OM_RATIS_MINIMUM_TIMEOUT_KEY, 1,
+        TimeUnit.SECONDS);
+    conf.set(HDDS_INITIAL_HEARTBEAT_INTERVAL, "500ms");
+    conf.set(HDDS_RECON_INITIAL_HEARTBEAT_INTERVAL, "500ms");
+    conf.set(HDDS_RATIS_LEADER_FIRST_ELECTION_MINIMUM_TIMEOUT_DURATION_KEY,
+        "1s");
+
+    SCMClientConfig scmClientConfig = conf.getObject(SCMClientConfig.class);
+    scmClientConfig.setMaxRetryTimeout(30_000);
+    conf.setFromObject(scmClientConfig);
+
+    PortAllocator ports = new PortAllocator();
+    int scmClientPort = ports.reserve(config.getScmPort());
+    int scmBlockPort = ports.reserve(0);
+    int scmDatanodePort = ports.reserve(0);
+    int scmSecurityPort = ports.reserve(0);
+    int scmHttpPort = ports.reserve(0);
+    int scmHttpsPort = ports.reserve(0);
+    int scmRatisPort = ports.reserve(0);
+    int scmGrpcPort = ports.reserve(0);
+
+    conf.set(OZONE_SCM_CLIENT_ADDRESS_KEY, address(config.getHost(), scmClientPort));
+    conf.set(OZONE_SCM_CLIENT_BIND_HOST_KEY, config.getBindHost());
+    conf.set(OZONE_SCM_BLOCK_CLIENT_ADDRESS_KEY,
+        address(config.getHost(), scmBlockPort));
+    conf.set(OZONE_SCM_BLOCK_CLIENT_BIND_HOST_KEY, config.getBindHost());
+    conf.set(OZONE_SCM_DATANODE_ADDRESS_KEY,
+        address(config.getHost(), scmDatanodePort));
+    conf.set(OZONE_SCM_DATANODE_BIND_HOST_KEY, config.getBindHost());
+    conf.set(OZONE_SCM_SECURITY_SERVICE_ADDRESS_KEY,
+        address(config.getHost(), scmSecurityPort));
+    conf.set(OZONE_SCM_SECURITY_SERVICE_BIND_HOST_KEY, config.getBindHost());
+    conf.set(OZONE_SCM_HTTP_ADDRESS_KEY, address(config.getHost(), scmHttpPort));
+    conf.set(OZONE_SCM_HTTP_BIND_HOST_KEY, config.getBindHost());
+    conf.set(ScmConfigKeys.OZONE_SCM_HTTPS_ADDRESS_KEY,
+        address(config.getHost(), scmHttpsPort));
+    conf.set(ScmConfigKeys.OZONE_SCM_HTTPS_BIND_HOST_KEY, config.getBindHost());
+    conf.setInt(OZONE_SCM_RATIS_PORT_KEY, scmRatisPort);
+    conf.setInt(OZONE_SCM_GRPC_PORT_KEY, scmGrpcPort);
+    conf.setStrings(OZONE_SCM_NAMES, address(config.getHost(), scmDatanodePort));
+
+    int omRpcPort = ports.reserve(config.getOmPort());
+    int omHttpPort = ports.reserve(0);
+    int omHttpsPort = ports.reserve(0);
+    int omRatisPort = ports.reserve(0);
+    conf.set(OZONE_OM_ADDRESS_KEY, address(config.getHost(), omRpcPort));
+    conf.set(OZONE_OM_HTTP_ADDRESS_KEY, address(config.getHost(), omHttpPort));
+    conf.set(OZONE_OM_HTTP_BIND_HOST_KEY, config.getBindHost());
+    conf.set(OZONE_OM_HTTPS_ADDRESS_KEY,
+        address(config.getHost(), omHttpsPort));
+    conf.set(OZONE_OM_HTTPS_BIND_HOST_KEY, config.getBindHost());
+    conf.setInt(OZONE_OM_RATIS_PORT_KEY, omRatisPort);
+
+    if (config.isS3gEnabled()) {
+      int s3gHttpPort = ports.reserve(config.getS3gPort());
+      int s3gHttpsPort = ports.reserve(0);
+      int s3gWebHttpPort = ports.reserve(0);
+      int s3gWebHttpsPort = ports.reserve(0);
+      conf.set(OZONE_S3G_HTTP_ADDRESS_KEY, address(config.getHost(),
+          s3gHttpPort));
+      conf.set(OZONE_S3G_HTTP_BIND_HOST_KEY, config.getBindHost());
+      conf.set(OZONE_S3G_HTTPS_ADDRESS_KEY, address(config.getHost(),
+          s3gHttpsPort));
+      conf.set(OZONE_S3G_HTTPS_BIND_HOST_KEY, config.getBindHost());
+      conf.set(OZONE_S3G_WEBADMIN_HTTP_ADDRESS_KEY,
+          address(config.getHost(), s3gWebHttpPort));
+      conf.set(OZONE_S3G_WEBADMIN_HTTP_BIND_HOST_KEY, config.getBindHost());
+      conf.set(OZONE_S3G_WEBADMIN_HTTPS_ADDRESS_KEY,
+          address(config.getHost(), s3gWebHttpsPort));
+      conf.set(OZONE_S3G_WEBADMIN_HTTPS_BIND_HOST_KEY, config.getBindHost());
+      preparedConfiguration = new PreparedConfiguration(conf, scmClientPort,
+          omRpcPort, s3gHttpPort);
+    } else {
+      preparedConfiguration = new PreparedConfiguration(conf, scmClientPort,
+          omRpcPort, -1);
+    }
+    return preparedConfiguration;
+  }
+
+  public int getScmPort() {
+    return scm != null ? scm.getClientRpcAddress().getPort()
+        : preparedConfiguration.getScmPort();
+  }
+
+  public int getOmPort() {
+    return om != null ? om.getOmRpcServerAddr().getPort()
+        : preparedConfiguration.getOmPort();
+  }
+
+  public int getS3gPort() {
+    if (!config.isS3gEnabled()) {
+      return -1;
+    }
+    return s3Gateway != null ? s3Gateway.getHttpAddress().getPort()
+        : preparedConfiguration.getS3gPort();
+  }
+
+  public String getDisplayHost() {
+    return "0.0.0.0".equals(config.getHost()) ? LocalOzoneClusterConfig.DEFAULT_HOST
+        : config.getHost();
+  }
+
+  public String getS3Endpoint() {
+    if (!config.isS3gEnabled()) {
+      return "";
+    }
+    return "http://" + getDisplayHost() + ":" + getS3gPort();
+  }
+
+  @Override
+  public void close() {
+    if (!closed.compareAndSet(false, true)) {
+      return;
+    }
+
+    OzoneConfigurationHolder.resetConfiguration();
+    stopQuietly(s3Gateway, "S3 gateway", gateway -> gateway.stop());
+    stopDatanodes();
+    stopQuietly(om, "Ozone Manager", manager -> {
+      if (manager.stop()) {
+        manager.join();
+      }
+    });
+    stopQuietly(scm, "SCM", manager -> {
+      manager.stop();
+      manager.join();
+    });
+
+    if (config.isEphemeral()) {
+      FileUtils.deleteQuietly(config.getDataDir().toFile());
+    }
+  }
+
+  private void initializeStorage(OzoneConfiguration conf) throws Exception {
+    SCMStorageConfig scmStorage = new SCMStorageConfig(conf);
+    OMStorage omStorage = new OMStorage(conf);
+
+    String clusterId = existingClusterId(scmStorage, omStorage);
+    if (scmStorage.getState() != INITIALIZED) {
+      requireFormatting("SCM");
+      String scmId = UUID.randomUUID().toString();
+      scmStorage.setClusterId(clusterId);
+      scmStorage.setScmId(scmId);
+      scmStorage.initialize();
+      scmStorage.setSCMHAFlag(true);
+      scmStorage.persistCurrentState();
+      SCMRatisServerImpl.initialize(clusterId, scmId,
+          SCMHANodeDetails.loadSCMHAConfig(conf, scmStorage)
+              .getLocalNodeDetails(), conf);
+    }
+
+    if (omStorage.getState() != INITIALIZED) {
+      requireFormatting("OM");
+      omStorage.setClusterId(clusterId);
+      omStorage.setOmId(UUID.randomUUID().toString());
+      if (OzoneSecurityUtil.isSecurityEnabled(conf)) {
+        OzoneManager.initializeSecurity(conf, omStorage, scmStorage.getScmId());
+      }
+      omStorage.initialize();
+    } else if (!clusterId.equals(omStorage.getClusterID())) {
+      throw new IOException("OM metadata belongs to a different cluster ID: "
+          + omStorage.getClusterID());
+    }
+  }
+
+  private void startDatanodes(OzoneConfiguration baseConf) throws IOException {
+    for (int index = 0; index < config.getDatanodes(); index++) {
+      OzoneConfiguration dnConf = new OzoneConfiguration(baseConf);
+      Path datanodeDir = createDirectory("datanode-" + (index + 1));
+      Path metaDir = Files.createDirectories(datanodeDir.resolve("metadata"));
+      dnConf.set(OZONE_METADATA_DIRS, metaDir.toString());
+
+      Path dataDir = Files.createDirectories(datanodeDir.resolve("data-0"));
+      dnConf.set(HDDS_DATANODE_DIR_KEY, dataDir.toString());
+
+      Path ratisDir = Files.createDirectories(datanodeDir.resolve("ratis"));
+      dnConf.set(HDDS_CONTAINER_RATIS_DATANODE_STORAGE_DIR, ratisDir.toString());
+
+      PortAllocator ports = new PortAllocator();
+      dnConf.set(HDDS_DATANODE_HTTP_ADDRESS_KEY,
+          address(config.getHost(), ports.reserve(0)));
+      dnConf.set(HDDS_DATANODE_HTTP_BIND_HOST_KEY, config.getBindHost());
+      dnConf.set(HDDS_DATANODE_CLIENT_ADDRESS_KEY,
+          address(config.getHost(), ports.reserve(0)));
+      dnConf.set(HDDS_DATANODE_CLIENT_BIND_HOST_KEY, config.getBindHost());
+      dnConf.setInt(HDDS_CONTAINER_IPC_PORT, ports.reserve(0));
+      dnConf.setInt(HDDS_CONTAINER_RATIS_IPC_PORT, ports.reserve(0));
+      dnConf.setInt(HDDS_CONTAINER_RATIS_ADMIN_PORT, ports.reserve(0));
+      dnConf.setInt(HDDS_CONTAINER_RATIS_SERVER_PORT, ports.reserve(0));
+      dnConf.setInt(HDDS_CONTAINER_RATIS_DATASTREAM_PORT, ports.reserve(0));
+      dnConf.setFromObject(new ReplicationServer.ReplicationConfig()
+          .setPort(ports.reserve(0)));
+
+      HddsDatanodeService datanode = new HddsDatanodeService(NO_ARGS);
+      datanode.setConfiguration(dnConf);
+      datanode.start(dnConf);
+      datanodes.add(datanode);
+    }
+  }
+
+  private void startS3Gateway(OzoneConfiguration baseConf) throws Exception {
+    OzoneConfigurationHolder.resetConfiguration();
+    OzoneConfigurationHolder.setConfiguration(new OzoneConfiguration(baseConf));
+    s3Gateway = new Gateway();
+    int exitCode = s3Gateway.execute(NO_ARGS);
+    if (exitCode != 0) {
+      throw new IOException("Failed to start local S3 gateway. Exit code="
+          + exitCode);
+    }
+  }
+
+  private void waitForClusterToBeReady(Duration timeout)
+      throws TimeoutException, InterruptedException {
+    long deadline = System.nanoTime() + timeout.toNanos();
+    while (System.nanoTime() < deadline) {
+      if (scm != null && scm.checkLeader()
+          && scm.getNodeCount(HEALTHY) == datanodes.size()
+          && !scm.isInSafeMode()) {
+        return;
+      }
+      Thread.sleep(1_000L);
+    }
+    throw new TimeoutException("Timed out waiting for local Ozone cluster to "
+        + "become ready after " + timeout);
+  }
+
+  private void requireFormatting(String component) throws IOException {
+    if (config.getFormatMode() == FormatMode.NEVER) {
+      throw new IOException(component + " storage is not initialized under "
+          + config.getDataDir() + ". Use --format if-needed or --format always.");
+    }
+  }
+
+  private String existingClusterId(SCMStorageConfig scmStorage,
+      OMStorage omStorage) {
+    if (scmStorage.getState() == INITIALIZED) {
+      return scmStorage.getClusterID();
+    }
+    if (omStorage.getState() == INITIALIZED) {
+      return omStorage.getClusterID();
+    }
+    return UUID.randomUUID().toString();
+  }
+
+  private Path createDirectory(String name) throws IOException {
+    return Files.createDirectories(config.getDataDir().resolve(name));
+  }
+
+  private void stopDatanodes() {
+    for (int index = datanodes.size() - 1; index >= 0; index--) {
+      HddsDatanodeService datanode = datanodes.get(index);
+      stopQuietly(datanode, "Datanode", service -> {
+        service.stop();
+        service.join();
+      });
+    }
+    datanodes.clear();
+  }
+
+  private static String address(String host, int port) {
+    return host + ":" + port;
+  }
+
+  private static <T> void stopQuietly(T service, String name,
+      ThrowingConsumer<T> stopAction) {
+    if (service == null) {
+      return;
+    }
+    try {
+      stopAction.accept(service);
+    } catch (Exception ex) {
+      LOG.warn("Failed to stop {}", name, ex);
+    }
+  }
+
+  @FunctionalInterface
+  private interface ThrowingConsumer<T> {
+    void accept(T value) throws Exception;
+  }
+
+  static final class PreparedConfiguration {
+    private final OzoneConfiguration configuration;
+    private final int scmPort;
+    private final int omPort;
+    private final int s3gPort;
+
+    PreparedConfiguration(OzoneConfiguration configuration, int scmPort,
+        int omPort, int s3gPort) {
+      this.configuration = configuration;
+      this.scmPort = scmPort;
+      this.omPort = omPort;
+      this.s3gPort = s3gPort;
+    }
+
+    OzoneConfiguration getConfiguration() {
+      return configuration;
+    }
+
+    int getScmPort() {
+      return scmPort;
+    }
+
+    int getOmPort() {
+      return omPort;
+    }
+
+    int getS3gPort() {
+      return s3gPort;
+    }
+  }
+
+  /**
+   * Small production-safe free-port allocator for local runtime setup.
+   */
+  static final class PortAllocator {
+    private final Set<Integer> reserved = new HashSet<>();
+
+    int reserve(int preferredPort) throws IOException {
+      if (preferredPort > 0) {
+        if (!reserved.add(preferredPort)) {
+          throw new IOException("Port " + preferredPort
+              + " is configured more than once.");
+        }
+        return preferredPort;
+      }
+
+      while (true) {
+        int candidate = nextFreePort();
+        if (reserved.add(candidate)) {
+          return candidate;
+        }
+      }
+    }
+
+    private static int nextFreePort() throws IOException {
+      try (ServerSocket socket = new ServerSocket(0)) {
+        socket.setReuseAddress(false);
+        return socket.getLocalPort();
+      }
+    }
+  }
+}

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/local/LocalOzoneClusterConfig.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/local/LocalOzoneClusterConfig.java
@@ -1,0 +1,239 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.local;
+
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Locale;
+import java.util.Objects;
+
+/**
+ * Configuration for a single-node local Ozone cluster.
+ */
+public final class LocalOzoneClusterConfig {
+
+  static final String DEFAULT_HOST = "127.0.0.1";
+  static final String DEFAULT_BIND_HOST = "0.0.0.0";
+  static final int DEFAULT_DATANODES = 1;
+  static final Duration DEFAULT_STARTUP_TIMEOUT = Duration.ofMinutes(2);
+  static final String DEFAULT_S3_ACCESS_KEY = "admin";
+  static final String DEFAULT_S3_SECRET_KEY = "admin123";
+  static final String DEFAULT_S3_REGION = "us-east-1";
+
+  private final Path dataDir;
+  private final FormatMode formatMode;
+  private final int datanodes;
+  private final boolean ephemeral;
+  private final boolean s3gEnabled;
+  private final String host;
+  private final String bindHost;
+  private final int scmPort;
+  private final int omPort;
+  private final int s3gPort;
+  private final Duration startupTimeout;
+  private final String s3AccessKey;
+  private final String s3SecretKey;
+  private final String s3Region;
+
+  private LocalOzoneClusterConfig(Builder builder) {
+    this.dataDir = Objects.requireNonNull(builder.dataDir, "dataDir");
+    this.formatMode = Objects.requireNonNull(builder.formatMode, "formatMode");
+    this.datanodes = builder.datanodes;
+    this.ephemeral = builder.ephemeral;
+    this.s3gEnabled = builder.s3gEnabled;
+    this.host = Objects.requireNonNull(builder.host, "host");
+    this.bindHost = Objects.requireNonNull(builder.bindHost, "bindHost");
+    this.scmPort = builder.scmPort;
+    this.omPort = builder.omPort;
+    this.s3gPort = builder.s3gPort;
+    this.startupTimeout = Objects.requireNonNull(builder.startupTimeout,
+        "startupTimeout");
+    this.s3AccessKey = Objects.requireNonNull(builder.s3AccessKey,
+        "s3AccessKey");
+    this.s3SecretKey = Objects.requireNonNull(builder.s3SecretKey,
+        "s3SecretKey");
+    this.s3Region = Objects.requireNonNull(builder.s3Region, "s3Region");
+  }
+
+  public Path getDataDir() {
+    return dataDir;
+  }
+
+  public FormatMode getFormatMode() {
+    return formatMode;
+  }
+
+  public int getDatanodes() {
+    return datanodes;
+  }
+
+  public boolean isEphemeral() {
+    return ephemeral;
+  }
+
+  public boolean isS3gEnabled() {
+    return s3gEnabled;
+  }
+
+  public String getHost() {
+    return host;
+  }
+
+  public String getBindHost() {
+    return bindHost;
+  }
+
+  public int getScmPort() {
+    return scmPort;
+  }
+
+  public int getOmPort() {
+    return omPort;
+  }
+
+  public int getS3gPort() {
+    return s3gPort;
+  }
+
+  public Duration getStartupTimeout() {
+    return startupTimeout;
+  }
+
+  public String getS3AccessKey() {
+    return s3AccessKey;
+  }
+
+  public String getS3SecretKey() {
+    return s3SecretKey;
+  }
+
+  public String getS3Region() {
+    return s3Region;
+  }
+
+  public static Builder builder(Path dataDir) {
+    return new Builder(dataDir);
+  }
+
+  /**
+   * Storage initialization mode.
+   */
+  public enum FormatMode {
+    IF_NEEDED,
+    ALWAYS,
+    NEVER;
+
+    public static FormatMode fromString(String value) {
+      return valueOf(value.trim().toUpperCase(Locale.ROOT).replace('-', '_'));
+    }
+  }
+
+  /**
+   * Builder for {@link LocalOzoneClusterConfig}.
+   */
+  public static final class Builder {
+
+    private final Path dataDir;
+    private FormatMode formatMode = FormatMode.IF_NEEDED;
+    private int datanodes = DEFAULT_DATANODES;
+    private boolean ephemeral;
+    private boolean s3gEnabled = true;
+    private String host = DEFAULT_HOST;
+    private String bindHost = DEFAULT_BIND_HOST;
+    private int scmPort;
+    private int omPort;
+    private int s3gPort;
+    private Duration startupTimeout = DEFAULT_STARTUP_TIMEOUT;
+    private String s3AccessKey = DEFAULT_S3_ACCESS_KEY;
+    private String s3SecretKey = DEFAULT_S3_SECRET_KEY;
+    private String s3Region = DEFAULT_S3_REGION;
+
+    private Builder(Path dataDir) {
+      this.dataDir = dataDir.toAbsolutePath().normalize();
+    }
+
+    public Builder setFormatMode(FormatMode value) {
+      this.formatMode = value;
+      return this;
+    }
+
+    public Builder setDatanodes(int value) {
+      this.datanodes = value;
+      return this;
+    }
+
+    public Builder setEphemeral(boolean value) {
+      this.ephemeral = value;
+      return this;
+    }
+
+    public Builder setS3gEnabled(boolean value) {
+      this.s3gEnabled = value;
+      return this;
+    }
+
+    public Builder setHost(String value) {
+      this.host = value;
+      return this;
+    }
+
+    public Builder setBindHost(String value) {
+      this.bindHost = value;
+      return this;
+    }
+
+    public Builder setScmPort(int value) {
+      this.scmPort = value;
+      return this;
+    }
+
+    public Builder setOmPort(int value) {
+      this.omPort = value;
+      return this;
+    }
+
+    public Builder setS3gPort(int value) {
+      this.s3gPort = value;
+      return this;
+    }
+
+    public Builder setStartupTimeout(Duration value) {
+      this.startupTimeout = value;
+      return this;
+    }
+
+    public Builder setS3AccessKey(String value) {
+      this.s3AccessKey = value;
+      return this;
+    }
+
+    public Builder setS3SecretKey(String value) {
+      this.s3SecretKey = value;
+      return this;
+    }
+
+    public Builder setS3Region(String value) {
+      this.s3Region = value;
+      return this;
+    }
+
+    public LocalOzoneClusterConfig build() {
+      return new LocalOzoneClusterConfig(this);
+    }
+  }
+}

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/local/OzoneLocal.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/local/OzoneLocal.java
@@ -1,0 +1,380 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.local;
+
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.time.format.DateTimeParseException;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.hdds.cli.GenericCli;
+import org.apache.hadoop.hdds.cli.HddsVersionProvider;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.ratis.util.ExitUtils;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.ParentCommand;
+import picocli.CommandLine.Spec;
+
+/**
+ * CLI entrypoint for local single-node Ozone.
+ */
+@Command(name = "ozone local",
+    description = "Run a single-node local Ozone cluster",
+    versionProvider = HddsVersionProvider.class,
+    mixinStandardHelpOptions = true,
+    subcommands = {
+        OzoneLocal.RunCommand.class
+    })
+public class OzoneLocal extends GenericCli {
+
+  static final String ENV_DATA_DIR = "OZONE_LOCAL_DATA_DIR";
+  static final String ENV_FORMAT = "OZONE_LOCAL_FORMAT";
+  static final String ENV_DATANODES = "OZONE_LOCAL_DATANODES";
+  static final String ENV_HOST = "OZONE_LOCAL_HOST";
+  static final String ENV_BIND_HOST = "OZONE_LOCAL_BIND_HOST";
+  static final String ENV_SCM_PORT = "OZONE_LOCAL_SCM_PORT";
+  static final String ENV_OM_PORT = "OZONE_LOCAL_OM_PORT";
+  static final String ENV_S3G_ENABLED = "OZONE_LOCAL_S3G_ENABLED";
+  static final String ENV_S3G_PORT = "OZONE_LOCAL_S3G_PORT";
+  static final String ENV_EPHEMERAL = "OZONE_LOCAL_EPHEMERAL";
+  static final String ENV_STARTUP_TIMEOUT = "OZONE_LOCAL_STARTUP_TIMEOUT";
+  static final String ENV_S3_ACCESS_KEY = "OZONE_LOCAL_S3_ACCESS_KEY";
+  static final String ENV_S3_SECRET_KEY = "OZONE_LOCAL_S3_SECRET_KEY";
+
+  public static void main(String[] args) {
+    ExitUtils.disableSystemExit();
+    new OzoneLocal().run(args);
+  }
+
+  /**
+   * Runs a local cluster.
+   */
+  @Command(name = "run",
+      description = "Start SCM, OM, datanodes, and optional S3 Gateway in one process")
+  static class RunCommand implements Callable<Void> {
+
+    @ParentCommand
+    private OzoneLocal parent;
+
+    @Spec
+    private CommandSpec spec;
+
+    private final Map<String, String> environment;
+
+    @Option(names = "--data-dir",
+        description = "Persistent data directory for the local cluster")
+    private String dataDir;
+
+    @Option(names = "--format",
+        description = "Storage init mode: if-needed, always, never")
+    private String format;
+
+    @Option(names = "--datanodes",
+        description = "Number of datanodes to start")
+    private Integer datanodes;
+
+    @Option(names = "--host",
+        description = "Advertised host to write into local service addresses")
+    private String host;
+
+    @Option(names = "--bind-host",
+        description = "Bind host for HTTP and RPC listeners")
+    private String bindHost;
+
+    @Option(names = "--scm-port",
+        description = "SCM client RPC port (0 means auto-allocate)")
+    private Integer scmPort;
+
+    @Option(names = "--om-port",
+        description = "OM RPC port (0 means auto-allocate)")
+    private Integer omPort;
+
+    @Option(names = "--s3g-port",
+        description = "S3 Gateway HTTP port (0 means auto-allocate)")
+    private Integer s3gPort;
+
+    @Option(names = "--without-s3g",
+        description = "Disable S3 Gateway")
+    private boolean withoutS3g;
+
+    @Option(names = "--ephemeral",
+        description = "Delete the data directory on shutdown")
+    private boolean ephemeral;
+
+    @Option(names = "--startup-timeout",
+        description = "How long to wait for the local cluster to become ready")
+    private String startupTimeout;
+
+    @Option(names = "--s3-access-key",
+        description = "Suggested local AWS access key to print on startup")
+    private String s3AccessKey;
+
+    @Option(names = "--s3-secret-key",
+        description = "Suggested local AWS secret key to print on startup")
+    private String s3SecretKey;
+
+    RunCommand() {
+      this(System.getenv());
+    }
+
+    RunCommand(Map<String, String> environment) {
+      this.environment = Objects.requireNonNull(environment, "environment");
+    }
+
+    @Override
+    public Void call() throws Exception {
+      LocalOzoneClusterConfig config = resolveConfig(parent.getOzoneConf());
+      try (LocalOzoneCluster cluster = new LocalOzoneCluster(config,
+          new OzoneConfiguration(parent.getOzoneConf()))) {
+        cluster.start();
+        printSummary(cluster, config);
+
+        CountDownLatch stopped = new CountDownLatch(1);
+        Thread shutdownHook = new Thread(() -> {
+          cluster.close();
+          stopped.countDown();
+        }, "ozone-local-shutdown");
+        Runtime.getRuntime().addShutdownHook(shutdownHook);
+        try {
+          stopped.await();
+        } finally {
+          try {
+            Runtime.getRuntime().removeShutdownHook(shutdownHook);
+          } catch (IllegalStateException ignored) {
+            // JVM is already shutting down.
+          }
+        }
+      }
+      return null;
+    }
+
+    LocalOzoneClusterConfig resolveConfig(OzoneConfiguration baseConfiguration) {
+      Path resolvedDataDir = resolvePath(dataDir, environment.get(ENV_DATA_DIR),
+          ENV_DATA_DIR,
+          Paths.get(System.getProperty("user.home"), ".ozone", "local"));
+      LocalOzoneClusterConfig.FormatMode resolvedFormat = format != null
+          ? parseFormat(format, "--format")
+          : parseFormat(environment.get(ENV_FORMAT), ENV_FORMAT,
+              LocalOzoneClusterConfig.FormatMode.IF_NEEDED);
+      int resolvedDatanodes = datanodes != null ? datanodes
+          : parseInt(environment.get(ENV_DATANODES), ENV_DATANODES,
+              LocalOzoneClusterConfig.DEFAULT_DATANODES);
+      if (resolvedDatanodes < 1) {
+        throw new IllegalArgumentException("Datanode count must be at least 1.");
+      }
+
+      String resolvedHost = firstNonBlank(host, environment.get(ENV_HOST),
+          LocalOzoneClusterConfig.DEFAULT_HOST);
+      String resolvedBindHost = firstNonBlank(bindHost,
+          environment.get(ENV_BIND_HOST),
+          LocalOzoneClusterConfig.DEFAULT_BIND_HOST);
+
+      int resolvedScmPort = scmPort != null ? validatePort(scmPort, "--scm-port")
+          : parsePort(environment.get(ENV_SCM_PORT), ENV_SCM_PORT, 0);
+      int resolvedOmPort = omPort != null ? validatePort(omPort, "--om-port")
+          : parsePort(environment.get(ENV_OM_PORT), ENV_OM_PORT, 0);
+      int resolvedS3gPort = s3gPort != null ? validatePort(s3gPort, "--s3g-port")
+          : parsePort(environment.get(ENV_S3G_PORT), ENV_S3G_PORT, 0);
+
+      boolean resolvedS3gEnabled = withoutS3g ? false
+          : parseBoolean(environment.get(ENV_S3G_ENABLED), ENV_S3G_ENABLED, true);
+      boolean resolvedEphemeral = ephemeral || parseBoolean(
+          environment.get(ENV_EPHEMERAL), ENV_EPHEMERAL, false);
+
+      Duration resolvedStartupTimeout = startupTimeout != null
+          ? parseDuration(startupTimeout, "--startup-timeout", baseConfiguration)
+          : parseDuration(environment.get(ENV_STARTUP_TIMEOUT),
+              ENV_STARTUP_TIMEOUT,
+              LocalOzoneClusterConfig.DEFAULT_STARTUP_TIMEOUT,
+              baseConfiguration);
+      if (resolvedStartupTimeout.isZero() || resolvedStartupTimeout.isNegative()) {
+        throw new IllegalArgumentException("Startup timeout must be greater than zero.");
+      }
+
+      String resolvedAccessKey = firstNonBlank(s3AccessKey,
+          environment.get(ENV_S3_ACCESS_KEY),
+          LocalOzoneClusterConfig.DEFAULT_S3_ACCESS_KEY);
+      String resolvedSecretKey = firstNonBlank(s3SecretKey,
+          environment.get(ENV_S3_SECRET_KEY),
+          LocalOzoneClusterConfig.DEFAULT_S3_SECRET_KEY);
+
+      return LocalOzoneClusterConfig.builder(resolvedDataDir)
+          .setFormatMode(resolvedFormat)
+          .setDatanodes(resolvedDatanodes)
+          .setHost(resolvedHost)
+          .setBindHost(resolvedBindHost)
+          .setScmPort(resolvedScmPort)
+          .setOmPort(resolvedOmPort)
+          .setS3gPort(resolvedS3gPort)
+          .setS3gEnabled(resolvedS3gEnabled)
+          .setEphemeral(resolvedEphemeral)
+          .setStartupTimeout(resolvedStartupTimeout)
+          .setS3AccessKey(resolvedAccessKey)
+          .setS3SecretKey(resolvedSecretKey)
+          .build();
+    }
+
+    private void printSummary(LocalOzoneCluster cluster,
+        LocalOzoneClusterConfig config) {
+      spec.commandLine().getOut().printf("Local Ozone is running from %s%n",
+          config.getDataDir());
+      spec.commandLine().getOut().printf("SCM RPC: %s:%d%n",
+          cluster.getDisplayHost(), cluster.getScmPort());
+      spec.commandLine().getOut().printf("OM RPC: %s:%d%n",
+          cluster.getDisplayHost(), cluster.getOmPort());
+      if (config.isS3gEnabled()) {
+        spec.commandLine().getOut().printf("S3 endpoint: %s%n",
+            cluster.getS3Endpoint());
+        spec.commandLine().getOut().println("Suggested local AWS settings:");
+        spec.commandLine().getOut().printf("AWS_ACCESS_KEY_ID=%s%n",
+            config.getS3AccessKey());
+        spec.commandLine().getOut().printf("AWS_SECRET_ACCESS_KEY=%s%n",
+            config.getS3SecretKey());
+        spec.commandLine().getOut().printf("AWS_REGION=%s%n",
+            config.getS3Region());
+        spec.commandLine().getOut().printf("AWS_ENDPOINT_URL_S3=%s%n",
+            cluster.getS3Endpoint());
+        spec.commandLine().getOut().println("AWS_S3_FORCE_PATH_STYLE=true");
+        spec.commandLine().getOut().println("Note: insecure local S3 accepts any AWS credential pair.");
+      }
+      spec.commandLine().getOut().println("Press Ctrl+C to stop.");
+    }
+
+    private static String firstNonBlank(String first, String second,
+        String fallback) {
+      if (StringUtils.isNotBlank(first)) {
+        return first.trim();
+      }
+      if (StringUtils.isNotBlank(second)) {
+        return second.trim();
+      }
+      return fallback;
+    }
+
+    private static Path resolvePath(String cliValue, String envValue,
+        String source, Path fallback) {
+      String rawValue = firstNonBlank(cliValue, envValue, null);
+      if (StringUtils.isBlank(rawValue)) {
+        return fallback.toAbsolutePath().normalize();
+      }
+      try {
+        return Paths.get(rawValue).toAbsolutePath().normalize();
+      } catch (InvalidPathException ex) {
+        throw new IllegalArgumentException("Unable to parse " + source
+            + " as a filesystem path: " + rawValue, ex);
+      }
+    }
+
+    private static LocalOzoneClusterConfig.FormatMode parseFormat(String rawValue,
+        String source) {
+      try {
+        return LocalOzoneClusterConfig.FormatMode.fromString(rawValue);
+      } catch (IllegalArgumentException ex) {
+        throw new IllegalArgumentException("Unable to parse " + source
+            + ". Expected one of: if-needed, always, never.", ex);
+      }
+    }
+
+    private static LocalOzoneClusterConfig.FormatMode parseFormat(String rawValue,
+        String source, LocalOzoneClusterConfig.FormatMode fallback) {
+      if (StringUtils.isBlank(rawValue)) {
+        return fallback;
+      }
+      return parseFormat(rawValue, source);
+    }
+
+    private static int parseInt(String rawValue, String source, int fallback) {
+      if (StringUtils.isBlank(rawValue)) {
+        return fallback;
+      }
+      try {
+        return Integer.parseInt(rawValue.trim());
+      } catch (NumberFormatException ex) {
+        throw new IllegalArgumentException("Unable to parse " + source
+            + " as an integer: " + rawValue, ex);
+      }
+    }
+
+    private static boolean parseBoolean(String rawValue, String source,
+        boolean fallback) {
+      if (StringUtils.isBlank(rawValue)) {
+        return fallback;
+      }
+      Boolean parsed = BooleanUtils.toBooleanObject(rawValue.trim());
+      if (parsed == null) {
+        throw new IllegalArgumentException("Unable to parse " + source
+            + " as a boolean. Use true/false, yes/no, or on/off.");
+      }
+      return parsed;
+    }
+
+    private static int parsePort(String rawValue, String source, int fallback) {
+      return StringUtils.isBlank(rawValue) ? fallback
+          : validatePort(parseInt(rawValue, source, fallback), source);
+    }
+
+    private static int validatePort(int value, String source) {
+      if (value < 0 || value > 65_535) {
+        throw new IllegalArgumentException("Port value for " + source
+            + " must be between 0 and 65535.");
+      }
+      return value;
+    }
+
+    private static Duration parseDuration(String rawValue, String source,
+        Duration fallback, OzoneConfiguration baseConfiguration) {
+      if (StringUtils.isBlank(rawValue)) {
+        return fallback;
+      }
+      return parseDuration(rawValue, source, baseConfiguration);
+    }
+
+    private static Duration parseDuration(String rawValue, String source,
+        OzoneConfiguration baseConfiguration) {
+      try {
+        return Duration.parse(rawValue.trim());
+      } catch (DateTimeParseException ignored) {
+        OzoneConfiguration conf = new OzoneConfiguration(baseConfiguration);
+        String configKey = "ozone.local.duration.parse";
+        conf.set(configKey, rawValue.trim());
+        try {
+          long millis = conf.getTimeDuration(configKey, -1L,
+              TimeUnit.MILLISECONDS);
+          if (millis < 0) {
+            throw new IllegalArgumentException("Unable to parse " + source
+                + " as a duration. Use ISO-8601 like PT2M or Hadoop-style values like 120s.");
+          }
+          return Duration.ofMillis(millis);
+        } catch (RuntimeException ex) {
+          throw new IllegalArgumentException("Unable to parse " + source
+              + " as a duration. Use ISO-8601 like PT2M or Hadoop-style values like 120s.",
+              ex);
+        }
+      }
+    }
+  }
+}

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/local/TestLocalOzoneCluster.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/local/TestLocalOzoneCluster.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.local;
+
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CLIENT_ADDRESS_KEY;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_METADATA_DIRS;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
+import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_HTTP_ADDRESS_KEY;
+import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_HTTPS_ADDRESS_KEY;
+import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_WEBADMIN_HTTP_ADDRESS_KEY;
+import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_WEBADMIN_HTTPS_ADDRESS_KEY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Tests for {@link LocalOzoneCluster}.
+ */
+class TestLocalOzoneCluster {
+
+  @TempDir
+  private Path tempDir;
+
+  @Test
+  void prepareConfigurationUsesRequestedPrimaryPorts() throws Exception {
+    LocalOzoneClusterConfig config = LocalOzoneClusterConfig.builder(
+            tempDir.resolve("local-ozone"))
+        .setScmPort(9860)
+        .setOmPort(9862)
+        .setS3gPort(9878)
+        .build();
+
+    try (LocalOzoneCluster cluster =
+             new LocalOzoneCluster(config, new OzoneConfiguration())) {
+      LocalOzoneCluster.PreparedConfiguration prepared =
+          cluster.prepareConfiguration();
+      OzoneConfiguration conf = prepared.getConfiguration();
+
+      assertTrue(conf.get(OZONE_METADATA_DIRS)
+          .startsWith(tempDir.resolve("local-ozone").toString()));
+      assertTrue(conf.get(OZONE_SCM_CLIENT_ADDRESS_KEY).endsWith(":9860"));
+      assertTrue(conf.get(OZONE_OM_ADDRESS_KEY).endsWith(":9862"));
+      assertTrue(conf.get(OZONE_S3G_HTTP_ADDRESS_KEY).endsWith(":9878"));
+      assertEquals(9860, prepared.getScmPort());
+      assertEquals(9862, prepared.getOmPort());
+      assertEquals(9878, prepared.getS3gPort());
+    }
+  }
+
+  @Test
+  void prepareConfigurationAllocatesDistinctS3AuxiliaryPorts() throws Exception {
+    LocalOzoneClusterConfig config = LocalOzoneClusterConfig.builder(
+            tempDir.resolve("local-ozone"))
+        .setS3gPort(9878)
+        .build();
+
+    try (LocalOzoneCluster cluster =
+             new LocalOzoneCluster(config, new OzoneConfiguration())) {
+      OzoneConfiguration conf = cluster.prepareConfiguration().getConfiguration();
+
+      int httpPort = parsePort(conf.get(OZONE_S3G_HTTP_ADDRESS_KEY));
+      int httpsPort = parsePort(conf.get(OZONE_S3G_HTTPS_ADDRESS_KEY));
+      int webHttpPort = parsePort(conf.get(OZONE_S3G_WEBADMIN_HTTP_ADDRESS_KEY));
+      int webHttpsPort = parsePort(conf.get(OZONE_S3G_WEBADMIN_HTTPS_ADDRESS_KEY));
+
+      assertEquals(9878, httpPort);
+      assertNotEquals(httpPort, httpsPort);
+      assertNotEquals(httpPort, webHttpPort);
+      assertNotEquals(httpPort, webHttpsPort);
+      assertNotEquals(httpsPort, webHttpPort);
+      assertNotEquals(httpsPort, webHttpsPort);
+      assertNotEquals(webHttpPort, webHttpsPort);
+    }
+  }
+
+  private static int parsePort(String address) {
+    return Integer.parseInt(address.substring(address.lastIndexOf(':') + 1));
+  }
+}

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/local/TestOzoneLocal.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/local/TestOzoneLocal.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.local;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link OzoneLocal}.
+ */
+class TestOzoneLocal {
+
+  @Test
+  void resolveConfigUsesDefaultLocalS3Credentials() {
+    OzoneLocal.RunCommand command = new OzoneLocal.RunCommand(
+        Collections.emptyMap());
+
+    LocalOzoneClusterConfig config =
+        command.resolveConfig(new OzoneConfiguration());
+
+    assertEquals(Paths.get(System.getProperty("user.home"), ".ozone", "local")
+            .toAbsolutePath().normalize(),
+        config.getDataDir());
+    assertEquals(LocalOzoneClusterConfig.DEFAULT_S3_ACCESS_KEY,
+        config.getS3AccessKey());
+    assertEquals(LocalOzoneClusterConfig.DEFAULT_S3_SECRET_KEY,
+        config.getS3SecretKey());
+    assertEquals(LocalOzoneClusterConfig.DEFAULT_STARTUP_TIMEOUT,
+        config.getStartupTimeout());
+    assertTrue(config.isS3gEnabled());
+  }
+
+  @Test
+  void resolveConfigUsesEnvironmentOverrides() {
+    Map<String, String> env = new HashMap<>();
+    env.put(OzoneLocal.ENV_DATA_DIR, "target/ozone-local-test");
+    env.put(OzoneLocal.ENV_FORMAT, "always");
+    env.put(OzoneLocal.ENV_DATANODES, "2");
+    env.put(OzoneLocal.ENV_HOST, "localhost");
+    env.put(OzoneLocal.ENV_BIND_HOST, "0.0.0.0");
+    env.put(OzoneLocal.ENV_SCM_PORT, "9860");
+    env.put(OzoneLocal.ENV_OM_PORT, "9862");
+    env.put(OzoneLocal.ENV_S3G_ENABLED, "false");
+    env.put(OzoneLocal.ENV_EPHEMERAL, "true");
+    env.put(OzoneLocal.ENV_STARTUP_TIMEOUT, "120s");
+    env.put(OzoneLocal.ENV_S3_ACCESS_KEY, "dev");
+    env.put(OzoneLocal.ENV_S3_SECRET_KEY, "devsecret");
+
+    OzoneLocal.RunCommand command = new OzoneLocal.RunCommand(env);
+
+    LocalOzoneClusterConfig config =
+        command.resolveConfig(new OzoneConfiguration());
+
+    assertEquals(Paths.get("target/ozone-local-test").toAbsolutePath().normalize(),
+        config.getDataDir());
+    assertEquals(LocalOzoneClusterConfig.FormatMode.ALWAYS,
+        config.getFormatMode());
+    assertEquals(2, config.getDatanodes());
+    assertEquals("localhost", config.getHost());
+    assertEquals("0.0.0.0", config.getBindHost());
+    assertEquals(9860, config.getScmPort());
+    assertEquals(9862, config.getOmPort());
+    assertEquals(Duration.ofSeconds(120), config.getStartupTimeout());
+    assertEquals("dev", config.getS3AccessKey());
+    assertEquals("devsecret", config.getS3SecretKey());
+    assertTrue(config.isEphemeral());
+  }
+
+  @Test
+  void resolveConfigRejectsInvalidBooleanEnvironmentValue() {
+    Map<String, String> env = new HashMap<>();
+    env.put(OzoneLocal.ENV_S3G_ENABLED, "sometimes");
+    OzoneLocal.RunCommand command = new OzoneLocal.RunCommand(env);
+
+    IllegalArgumentException error = assertThrows(IllegalArgumentException.class,
+        () -> command.resolveConfig(new OzoneConfiguration()));
+
+    assertTrue(error.getMessage().contains(OzoneLocal.ENV_S3G_ENABLED));
+  }
+
+  @Test
+  void resolveConfigRejectsInvalidDurationEnvironmentValue() {
+    Map<String, String> env = new HashMap<>();
+    env.put(OzoneLocal.ENV_STARTUP_TIMEOUT, "forever");
+    OzoneLocal.RunCommand command = new OzoneLocal.RunCommand(env);
+
+    IllegalArgumentException error = assertThrows(IllegalArgumentException.class,
+        () -> command.resolveConfig(new OzoneConfiguration()));
+
+    assertTrue(error.getMessage().contains(OzoneLocal.ENV_STARTUP_TIMEOUT));
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pull request introduces several improvements and new features, primarily focused on enhancing tracing configurability, improving resource management, and adding atomic key creation semantics. It also includes some minor documentation corrections.

**Tracing and Sampling Enhancements:**

* Added support for span-level sampling configuration via the new environment variable `OTEL_SPAN_SAMPLING_ARG`. Users can now specify sampling rates for individual span names, allowing for fine-grained tracing control. The core logic is implemented in the new `SpanSampler` and `LoopSampler` classes, with integration and configuration parsing handled in `TracingUtil`. [[1]](diffhunk://#diff-371ae528045a1351d4d77815d1693329361461237b90c98fa1929ee10301ef09R1-R90) [[2]](diffhunk://#diff-00dc42323e206e5b402703d28288c0dfc74574bda9b84120af2b81971b67b139R1-R46) [[3]](diffhunk://#diff-f7b36257dcaa270cad90a256360ed515a7be7752e2972230a73462d59674d302R56-R57) [[4]](diffhunk://#diff-f7b36257dcaa270cad90a256360ed515a7be7752e2972230a73462d59674d302R94-R137) [[5]](diffhunk://#diff-f7b36257dcaa270cad90a256360ed515a7be7752e2972230a73462d59674d302R211-R248)
* The `TracingUtil` class now logs configuration issues and falls back to defaults if invalid values are provided for trace or span sampling rates.
* The tracing system now chooses between standard trace-based sampling and the new span-based sampling based on the presence of span sampling configuration.

**Resource Management Improvements:**

* The `RandomAccessFileChannel` class now implements `Closeable` and improves resource cleanup logic. It ensures that both the file channel and the underlying `RandomAccessFile` are closed safely, with improved error handling and logging. [[1]](diffhunk://#diff-6175e03100e2701ee94828643c9ca2c4abb29628565803a12e9fb157ab694b3eL32-R33) [[2]](diffhunk://#diff-6175e03100e2701ee94828643c9ca2c4abb29628565803a12e9fb157ab694b3eR93-R117)
* The `open` method in `RandomAccessFileChannel` is now safer, avoiding resource leaks by only updating internal state after all resources are successfully allocated.

**Atomic Key Creation Semantics:**

* Added a new sentinel constant, `EXPECTED_GEN_CREATE_IF_NOT_EXISTS`, to `OzoneConsts` to support atomic "create-if-not-exists" semantics for key creation.
* Introduced a new `OzoneManagerVersion` entry, `ATOMIC_CREATE_IF_NOT_EXISTS`, to indicate support for this feature.

**Pipeline and Datanode Improvements:**

* Added a helper method `hasPort` to `DatanodeDetails` for checking if a specific port is present, without compatibility fallback.
* Updated `BlockDataStreamOutput` to validate that all datanodes in a pipeline have the required `RATIS_DATASTREAM` port before proceeding, improving error detection for misconfigured pipelines.

**Documentation and Minor Fixes:**

* Fixed outdated download URLs in `README.md` and `SECURITY.md` to point to the correct Ozone download page. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L49-R49) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L87-R87) [[3]](diffhunk://#diff-f6ed156e4bf5c791680662464b94ea5d753f219ee816b385f67870e2c0d7d4c7L5-R5)
* Fixed a minor typo in `RandomAccessFileChannel` documentation.

These changes collectively improve the configurability, reliability, and clarity of the codebase.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-14893

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests, workflow run on the fork git repo.)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this.)
