### PR TITLE
HDDS-15125. MVCC-Style Snapshot Reclaimability Using seqNumMin / seqNumMax

### DIFF
--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -2430,6 +2430,19 @@
   </property>
 
   <property>
+    <name>ozone.om.snapshot.key.reclaim.interval.enabled</name>
+    <value>true</value>
+    <tag>OZONE, OM, MANAGEMENT, PERFORMANCE</tag>
+    <description>
+      Enables MVCC-style deleted key reclaimability checks using optional
+      seqNumMin and seqNumMax fields on key versions. Entries without complete
+      sequence interval metadata, or buckets whose active snapshot create
+      sequence numbers cannot be built exactly, fall back to the previous
+      snapshot lookup based reclaimability logic.
+    </description>
+  </property>
+
+  <property>
     <name>ozone.acl.authorizer.class</name>
     <value>org.apache.hadoop.ozone.security.acl.OzoneAccessAuthorizer</value>
     <tag>OZONE, SECURITY, ACL</tag>

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -640,6 +640,9 @@ public final class OmUtils {
    * create a new instance to include this key, else we update the existing
    * repeatedOmKeyInfo instance.
    * 3. Set the updateID to the transactionLogIndex.
+   * 4. Set seqNumMax to the transactionLogIndex when seqNumMin is present,
+   *    making the interval exclusive at the transaction that deleted or
+   *    overwrote this version.
    * @param keyInfo args supplied by client
    * @param bucketId bucket id
    * @param trxnLogIndex For Multipart keys, this is the transactionLogIndex
@@ -667,6 +670,9 @@ public final class OmUtils {
 
     // Set the updateID
     builder.setUpdateID(trxnLogIndex);
+    if (keyInfo.hasSeqNumMin()) {
+      builder.setSeqNumMax(trxnLogIndex);
+    }
 
     //The key doesn't exist in deletedTable, so create a new instance.
     return new RepeatedOmKeyInfo(builder.build(), bucketId);

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -292,6 +292,11 @@ public final class OMConfigKeys {
       "ozone.om.fs.snapshot.max.limit";
   public static final int OZONE_OM_FS_SNAPSHOT_MAX_LIMIT_DEFAULT = 10000;
 
+  public static final String OZONE_OM_SNAPSHOT_KEY_RECLAIM_INTERVAL_ENABLED =
+      "ozone.om.snapshot.key.reclaim.interval.enabled";
+  public static final boolean
+      OZONE_OM_SNAPSHOT_KEY_RECLAIM_INTERVAL_ENABLED_DEFAULT = true;
+
   public static final String OZONE_OM_KERBEROS_KEYTAB_FILE_KEY = "ozone.om."
       + "kerberos.keytab.file";
   public static final String OZONE_OM_KERBEROS_PRINCIPAL_KEY = "ozone.om"

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
@@ -111,6 +111,8 @@ public final class OmKeyInfo extends WithParentObjectId
   // been modified.
   private Long expectedDataGeneration = null;
   private String expectedETag;
+  private Long seqNumMin;
+  private Long seqNumMax;
 
   private OmKeyInfo(Builder b) {
     super(b);
@@ -131,6 +133,8 @@ public final class OmKeyInfo extends WithParentObjectId
     this.tags = b.tags.build();
     this.expectedDataGeneration = b.expectedDataGeneration;
     this.expectedETag = b.expectedETag;
+    this.seqNumMin = b.seqNumMin;
+    this.seqNumMax = b.seqNumMax;
   }
 
   private static Codec<OmKeyInfo> newCodec(boolean ignorePipeline) {
@@ -197,6 +201,30 @@ public final class OmKeyInfo extends WithParentObjectId
 
   public String getExpectedETag() {
     return expectedETag;
+  }
+
+  public void setSeqNumMin(Long seqNumMin) {
+    this.seqNumMin = seqNumMin;
+  }
+
+  public Long getSeqNumMin() {
+    return seqNumMin;
+  }
+
+  public boolean hasSeqNumMin() {
+    return seqNumMin != null;
+  }
+
+  public void setSeqNumMax(Long seqNumMax) {
+    this.seqNumMax = seqNumMax;
+  }
+
+  public Long getSeqNumMax() {
+    return seqNumMax;
+  }
+
+  public boolean hasSeqNumMax() {
+    return seqNumMax != null;
   }
 
   public String getOwnerName() {
@@ -475,6 +503,8 @@ public final class OmKeyInfo extends WithParentObjectId
         ", fileChecksum=" + fileChecksum +
         ", isFile=" + isFile +
         ", fileName='" + fileName + '\'' +
+        ", seqNumMin=" + seqNumMin +
+        ", seqNumMax=" + seqNumMax +
         ", acls=" + acls +
         '}';
   }
@@ -503,6 +533,8 @@ public final class OmKeyInfo extends WithParentObjectId
     private final MapBuilder<String, String> tags;
     private Long expectedDataGeneration = null;
     private String expectedETag;
+    private Long seqNumMin;
+    private Long seqNumMax;
 
     public Builder() {
       this.acls = AclListBuilder.empty();
@@ -526,6 +558,8 @@ public final class OmKeyInfo extends WithParentObjectId
       this.isFile = obj.isFile;
       this.expectedDataGeneration = obj.expectedDataGeneration;
       this.expectedETag = obj.expectedETag;
+      this.seqNumMin = obj.seqNumMin;
+      this.seqNumMax = obj.seqNumMax;
       this.tags = MapBuilder.of(obj.tags);
       obj.keyLocationVersions.forEach(keyLocationVersion ->
           this.omKeyLocationInfoGroups.add(
@@ -702,6 +736,16 @@ public final class OmKeyInfo extends WithParentObjectId
       return this;
     }
 
+    public Builder setSeqNumMin(Long seqNum) {
+      this.seqNumMin = seqNum;
+      return this;
+    }
+
+    public Builder setSeqNumMax(Long seqNum) {
+      this.seqNumMax = seqNum;
+      return this;
+    }
+
     @Override
     protected void validate() {
       super.validate();
@@ -824,6 +868,12 @@ public final class OmKeyInfo extends WithParentObjectId
     if (expectedETag != null) {
       kb.setExpectedETag(expectedETag);
     }
+    if (seqNumMin != null) {
+      kb.setSeqNumMin(seqNumMin);
+    }
+    if (seqNumMax != null) {
+      kb.setSeqNumMax(seqNumMax);
+    }
     if (ownerName != null) {
       kb.setOwnerName(ownerName);
     }
@@ -880,6 +930,12 @@ public final class OmKeyInfo extends WithParentObjectId
     if (keyInfo.hasExpectedETag()) {
       builder.setExpectedETag(keyInfo.getExpectedETag());
     }
+    if (keyInfo.hasSeqNumMin()) {
+      builder.setSeqNumMin(keyInfo.getSeqNumMin());
+    }
+    if (keyInfo.hasSeqNumMax()) {
+      builder.setSeqNumMax(keyInfo.getSeqNumMax());
+    }
 
     if (keyInfo.hasOwnerName()) {
       builder.setOwnerName(keyInfo.getOwnerName());
@@ -903,6 +959,8 @@ public final class OmKeyInfo extends WithParentObjectId
         ", creationTime='" + creationTime + '\'' +
         ", objectID='" + getObjectID() + '\'' +
         ", parentID='" + getParentObjectID() + '\'' +
+        ", seqNumMin='" + seqNumMin + '\'' +
+        ", seqNumMax='" + seqNumMax + '\'' +
         ", replication='" + replicationConfig + '\'' +
         ", fileChecksum='" + fileChecksum +
         '}';
@@ -921,6 +979,8 @@ public final class OmKeyInfo extends WithParentObjectId
         Objects.equals(getMetadata(), omKeyInfo.getMetadata()) &&
         Objects.equals(acls, omKeyInfo.acls) &&
         Objects.equals(getTags(), omKeyInfo.getTags()) &&
+        Objects.equals(seqNumMin, omKeyInfo.seqNumMin) &&
+        Objects.equals(seqNumMax, omKeyInfo.seqNumMax) &&
         getObjectID() == omKeyInfo.getObjectID();
 
     if (isEqual && checkUpdateID) {

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmKeyInfo.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmKeyInfo.java
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
@@ -41,6 +42,7 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.apache.hadoop.ozone.ClientVersion;
+import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo.Builder;
@@ -71,6 +73,62 @@ public class TestOmKeyInfo {
         metadata -> metadata.put(OzoneConsts.HSYNC_CLIENT_ID, "clientid"));
     assertTrue(key.isHsync());
     assertEquals(5678L, key.getExpectedDataGeneration());
+  }
+
+  @Test
+  public void protobufConversionPreservesSeqNumIntervalPresence()
+      throws IOException {
+    OmKeyInfo key = createOmKeyInfo(
+        RatisReplicationConfig.getInstance(ReplicationFactor.THREE));
+    OzoneManagerProtocolProtos.KeyInfo proto =
+        key.getProtobuf(ClientVersion.CURRENT_VERSION);
+    assertFalse(proto.hasSeqNumMin());
+    assertFalse(proto.hasSeqNumMax());
+
+    OmKeyInfo recovered = OmKeyInfo.getFromProtobuf(proto);
+    assertNull(recovered.getSeqNumMin());
+    assertNull(recovered.getSeqNumMax());
+    assertFalse(recovered.hasSeqNumMin());
+    assertFalse(recovered.hasSeqNumMax());
+
+    key = key.toBuilder()
+        .setSeqNumMin(1234L)
+        .setSeqNumMax(5678L)
+        .build();
+    proto = key.getProtobuf(ClientVersion.CURRENT_VERSION);
+    assertTrue(proto.hasSeqNumMin());
+    assertTrue(proto.hasSeqNumMax());
+    assertEquals(1234L, proto.getSeqNumMin());
+    assertEquals(5678L, proto.getSeqNumMax());
+
+    recovered = OmKeyInfo.getFromProtobuf(proto);
+    assertEquals(1234L, recovered.getSeqNumMin());
+    assertEquals(5678L, recovered.getSeqNumMax());
+    assertTrue(recovered.hasSeqNumMin());
+    assertTrue(recovered.hasSeqNumMax());
+    assertEquals(key, recovered);
+  }
+
+  @Test
+  public void prepareKeyForDeletePreservesSeqNumMinAndSetsSeqNumMax() {
+    OmKeyInfo key = createOmKeyInfo(
+        RatisReplicationConfig.getInstance(ReplicationFactor.THREE))
+        .toBuilder()
+        .setSeqNumMin(11L)
+        .build();
+
+    RepeatedOmKeyInfo deletedKeyInfo =
+        OmUtils.prepareKeyForDelete(1L, key, 22L);
+    OmKeyInfo deletedKey = deletedKeyInfo.getOmKeyInfoList().get(0);
+    assertEquals(11L, deletedKey.getSeqNumMin());
+    assertEquals(22L, deletedKey.getSeqNumMax());
+
+    key = createOmKeyInfo(
+        RatisReplicationConfig.getInstance(ReplicationFactor.THREE));
+    deletedKeyInfo = OmUtils.prepareKeyForDelete(1L, key, 22L);
+    deletedKey = deletedKeyInfo.getOmKeyInfoList().get(0);
+    assertNull(deletedKey.getSeqNumMin());
+    assertNull(deletedKey.getSeqNumMax());
   }
 
   @Test

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -1197,6 +1197,12 @@ message KeyInfo {
     // the given ETag for the operation to succeed. This is used for
     // S3 conditional writes with the If-Match header.
     optional string expectedETag = 23;
+
+    // MVCC-style visibility interval for snapshot key reclamation.
+    // A key version is visible to a snapshot when:
+    // seqNumMin <= snapshotCreateSeqNum < seqNumMax.
+    optional uint64 seqNumMin = 24;
+    optional uint64 seqNumMax = 25;
 }
 
 // KeyInfoProtoLight is a lightweight subset of KeyInfo message containing

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/DeletingServiceMetrics.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/DeletingServiceMetrics.java
@@ -109,6 +109,10 @@ public final class DeletingServiceMetrics {
   private MutableGaugeLong snapKeysIteratedLast;
   @Metric("Snapshot: No. of not reclaimable keys the last run")
   private MutableGaugeLong snapKeysNotReclaimableLast;
+  @Metric("Snapshot: No. of key reclaimability decisions optimized by seqNum intervals")
+  private MutableGaugeLong snapKeyReclaimIntervalOptimized;
+  @Metric("Snapshot: No. of key reclaimability decisions falling back from seqNum intervals")
+  private MutableGaugeLong snapKeyReclaimIntervalFallback;
 
   /**
    * Metric to track the term ID of the last key that was purged from the
@@ -297,6 +301,22 @@ public final class DeletingServiceMetrics {
 
   public long getSnapKeysNotReclaimableLast() {
     return snapKeysNotReclaimableLast.value();
+  }
+
+  public void incrSnapKeyReclaimIntervalOptimized() {
+    this.snapKeyReclaimIntervalOptimized.incr(1L);
+  }
+
+  public long getSnapKeyReclaimIntervalOptimized() {
+    return snapKeyReclaimIntervalOptimized.value();
+  }
+
+  public void incrSnapKeyReclaimIntervalFallback() {
+    this.snapKeyReclaimIntervalFallback.incr(1L);
+  }
+
+  public long getSnapKeyReclaimIntervalFallback() {
+    return snapKeyReclaimIntervalFallback.value();
   }
 
   public synchronized TransactionInfo getLastAOSTransactionInfo() {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
@@ -313,6 +313,7 @@ public class OMKeyCommitRequest extends OMKeyRequest {
           .addAllMetadata(KeyValueUtil.getFromProtobuf(
                 commitKeyArgs.getMetadataList()))
           .setUpdateID(trxnLogIndex)
+          .setSeqNumMin(trxnLogIndex)
           .setDataSize(commitKeyArgs.getDataSize())
           .build();
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
@@ -231,6 +231,7 @@ public class OMKeyCommitRequestWithFSO extends OMKeyCommitRequest {
               commitKeyArgs.getMetadataList()))
           .setDataSize(commitKeyArgs.getDataSize())
           .setUpdateID(trxnLogIndex)
+          .setSeqNumMin(trxnLogIndex)
           .build();
 
       List<OmKeyLocationInfo> uncommitted =
@@ -318,8 +319,9 @@ public class OMKeyCommitRequestWithFSO extends OMKeyCommitRequest {
         if (null == oldKeyVersionsToDeleteMap) {
           oldKeyVersionsToDeleteMap = new HashMap<>();
         }
+        OmKeyInfo keyInfoToDelete = prepareKeyInfoForDeleteMap(trxnLogIndex, pseudoKeyInfo);
         oldKeyVersionsToDeleteMap.computeIfAbsent(delKeyName,
-            key -> new RepeatedOmKeyInfo(omBucketInfo.getObjectID())).addOmKeyInfo(pseudoKeyInfo);
+            key -> new RepeatedOmKeyInfo(omBucketInfo.getObjectID())).addOmKeyInfo(keyInfoToDelete);
       }
 
       // Add to cache of open key table and key table.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
@@ -1185,6 +1185,7 @@ public abstract class OMKeyRequest extends OMClientRequest {
     if (keyInfo == null) {
       return deleteMap;
     }
+    keyInfo = prepareKeyInfoForDeleteMap(trxnLogIndex, keyInfo);
     final long pseudoObjId = om.getObjectIdFromTxId(trxnLogIndex);
     final String delKeyName = om.getMetadataManager().getOzoneDeletePathKey(pseudoObjId, ozoneKey);
     if (deleteMap == null) {
@@ -1193,6 +1194,17 @@ public abstract class OMKeyRequest extends OMClientRequest {
     deleteMap.computeIfAbsent(delKeyName, key -> new RepeatedOmKeyInfo(bucketId))
         .addOmKeyInfo(keyInfo);
     return deleteMap;
+  }
+
+  protected static OmKeyInfo prepareKeyInfoForDeleteMap(long trxnLogIndex, OmKeyInfo keyInfo) {
+    if (keyInfo.getObjectID() == OBJECT_ID_RECLAIM_BLOCKS) {
+      return keyInfo.toBuilder()
+          .setUpdateID(trxnLogIndex)
+          .setSeqNumMin(trxnLogIndex)
+          .setSeqNumMax(trxnLogIndex)
+          .build();
+    }
+    return keyInfo;
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
@@ -520,7 +520,9 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
         builder.setTags(dbOpenKeyInfo.getTags());
       }
     }
-    return builder.setUpdateID(trxnLogIndex).build();
+    return builder.setUpdateID(trxnLogIndex)
+        .setSeqNumMin(trxnLogIndex)
+        .build();
   }
 
   protected String getDBOzoneKey(OMMetadataManager omMetadataManager,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/filter/ReclaimableKeyFilter.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/filter/ReclaimableKeyFilter.java
@@ -17,23 +17,37 @@
 
 package org.apache.hadoop.ozone.om.snapshot.filter;
 
+import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SNAPSHOT_KEY_RECLAIM_INTERVAL_ENABLED;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SNAPSHOT_KEY_RECLAIM_INTERVAL_ENABLED_DEFAULT;
+import static org.apache.hadoop.ozone.om.helpers.SnapshotInfo.SnapshotStatus.SNAPSHOT_ACTIVE;
 import static org.apache.hadoop.ozone.om.snapshot.SnapshotUtils.isBlockLocationInfoSame;
 
+import com.google.protobuf.ByteString;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.utils.TransactionInfo;
 import org.apache.hadoop.hdds.utils.db.Table;
+import org.apache.hadoop.ozone.om.DeletingServiceMetrics;
 import org.apache.hadoop.ozone.om.KeyManager;
 import org.apache.hadoop.ozone.om.OmSnapshot;
 import org.apache.hadoop.ozone.om.OmSnapshotManager;
 import org.apache.hadoop.ozone.om.OzoneManager;
+import org.apache.hadoop.ozone.om.SnapshotChainInfo;
 import org.apache.hadoop.ozone.om.SnapshotChainManager;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
 import org.apache.hadoop.ozone.om.lock.IOzoneManagerLock;
+import org.apache.hadoop.ozone.om.snapshot.SnapshotUtils;
 import org.apache.ratis.util.MemoizedCheckedSupplier;
 import org.apache.ratis.util.function.CheckedSupplier;
 import org.apache.ratis.util.function.UncheckedAutoCloseableSupplier;
@@ -43,8 +57,15 @@ import org.apache.ratis.util.function.UncheckedAutoCloseableSupplier;
  * the snapshot chain.
  */
 public class ReclaimableKeyFilter extends ReclaimableFilter<OmKeyInfo> {
+  private static final ActiveSnapshotSequences EMPTY_SEQUENCES =
+      new ActiveSnapshotSequences(new long[0], new UUID[0]);
+
   private final Map<UUID, Long> exclusiveSizeMap;
   private final Map<UUID, Long> exclusiveReplicatedSizeMap;
+  private final SnapshotChainManager snapshotChainManager;
+  private final SnapshotInfo currentSnapshotInfo;
+  private final boolean seqNumIntervalEnabled;
+  private final Map<String, Optional<ActiveSnapshotSequences>> activeSnapshotSequencesByPath;
 
   /**
    * @param currentSnapshotInfo  : If null the deleted keys in AOS needs to be processed, hence the latest snapshot
@@ -59,6 +80,13 @@ public class ReclaimableKeyFilter extends ReclaimableFilter<OmKeyInfo> {
     super(ozoneManager, omSnapshotManager, snapshotChainManager, currentSnapshotInfo, keyManager, lock, 2);
     this.exclusiveSizeMap = new HashMap<>();
     this.exclusiveReplicatedSizeMap = new HashMap<>();
+    this.snapshotChainManager = snapshotChainManager;
+    this.currentSnapshotInfo = currentSnapshotInfo;
+    OzoneConfiguration configuration = ozoneManager.getConfiguration();
+    this.seqNumIntervalEnabled = configuration == null ||
+        configuration.getBoolean(OZONE_OM_SNAPSHOT_KEY_RECLAIM_INTERVAL_ENABLED,
+            OZONE_OM_SNAPSHOT_KEY_RECLAIM_INTERVAL_ENABLED_DEFAULT);
+    this.activeSnapshotSequencesByPath = new HashMap<>();
   }
 
   @Override
@@ -69,6 +97,17 @@ public class ReclaimableKeyFilter extends ReclaimableFilter<OmKeyInfo> {
   @Override
   protected String getBucketName(Table.KeyValue<String, OmKeyInfo> keyValue) throws IOException {
     return keyValue.getValue().getBucketName();
+  }
+
+  @Override
+  public synchronized Boolean apply(Table.KeyValue<String, OmKeyInfo> keyValue) throws IOException {
+    Optional<Boolean> seqNumDecision = applySeqNumInterval(keyValue);
+    if (seqNumDecision.isPresent()) {
+      incrementSeqNumIntervalOptimized();
+      return seqNumDecision.get();
+    }
+    incrementSeqNumIntervalFallback();
+    return super.apply(keyValue);
   }
 
   @Override
@@ -124,6 +163,133 @@ public class ReclaimableKeyFilter extends ReclaimableFilter<OmKeyInfo> {
     return exclusiveReplicatedSizeMap;
   }
 
+  private Optional<Boolean> applySeqNumInterval(Table.KeyValue<String, OmKeyInfo> keyValue) throws IOException {
+    if (!seqNumIntervalEnabled) {
+      return Optional.empty();
+    }
+
+    OmKeyInfo keyInfo = keyValue.getValue();
+    if (!keyInfo.hasSeqNumMin() || !keyInfo.hasSeqNumMax()) {
+      return Optional.empty();
+    }
+
+    String volume = getVolumeName(keyValue);
+    String bucket = getBucketName(keyValue);
+    validateCurrentSnapshotPath(volume, bucket);
+
+    long seqNumMin = keyInfo.getSeqNumMin();
+    long seqNumMax = keyInfo.getSeqNumMax();
+    if (seqNumMin >= seqNumMax) {
+      return Optional.of(true);
+    }
+
+    Optional<ActiveSnapshotSequences> activeSnapshots = getActiveSnapshotSequences(volume, bucket);
+    if (!activeSnapshots.isPresent()) {
+      return Optional.empty();
+    }
+
+    ActiveSnapshotSequences snapshotSequences = activeSnapshots.get();
+    int pos = lowerBound(snapshotSequences.getCreateSeqNums(), seqNumMin);
+    boolean referenced = pos < snapshotSequences.getCreateSeqNums().length &&
+        snapshotSequences.getCreateSeqNums()[pos] < seqNumMax;
+    if (referenced) {
+      addExclusiveSize(snapshotSequences.getSnapshotIds()[pos], keyInfo);
+    }
+    return Optional.of(!referenced);
+  }
+
+  private void validateCurrentSnapshotPath(String volume, String bucket) throws IOException {
+    if (currentSnapshotInfo != null &&
+        (!currentSnapshotInfo.getVolumeName().equals(volume) ||
+            !currentSnapshotInfo.getBucketName().equals(bucket))) {
+      throw new IOException("Volume and Bucket name for snapshot : " + currentSnapshotInfo + " do not match " +
+          "against the volume: " + volume + " and bucket: " + bucket + " of the key.");
+    }
+  }
+
+  private Optional<ActiveSnapshotSequences> getActiveSnapshotSequences(String volume, String bucket)
+      throws IOException {
+    String snapshotPath = volume + OM_KEY_PREFIX + bucket;
+    Optional<ActiveSnapshotSequences> cached = activeSnapshotSequencesByPath.get(snapshotPath);
+    if (cached != null) {
+      return cached;
+    }
+
+    Optional<ActiveSnapshotSequences> activeSnapshots = buildActiveSnapshotSequences(snapshotPath);
+    activeSnapshotSequencesByPath.put(snapshotPath, activeSnapshots);
+    return activeSnapshots;
+  }
+
+  private Optional<ActiveSnapshotSequences> buildActiveSnapshotSequences(String snapshotPath) throws IOException {
+    LinkedHashMap<UUID, SnapshotChainInfo> snapshotChainPath =
+        snapshotChainManager.getSnapshotChainPath(snapshotPath);
+    if (snapshotChainPath == null || snapshotChainPath.isEmpty()) {
+      return Optional.of(EMPTY_SEQUENCES);
+    }
+
+    List<SnapshotSeqInfo> seqInfos = new ArrayList<>();
+    for (UUID snapshotId : snapshotChainPath.keySet()) {
+      SnapshotInfo snapshotInfo = SnapshotUtils.getSnapshotInfo(getOzoneManager(), snapshotChainManager, snapshotId);
+      if (snapshotInfo.getSnapshotStatus() != SNAPSHOT_ACTIVE) {
+        continue;
+      }
+      ByteString createTransactionInfo = snapshotInfo.getCreateTransactionInfo();
+      if (createTransactionInfo == null || createTransactionInfo.isEmpty()) {
+        return Optional.empty();
+      }
+      long createSeqNum = TransactionInfo.fromByteString(createTransactionInfo).getTransactionIndex();
+      seqInfos.add(new SnapshotSeqInfo(createSeqNum, snapshotId));
+    }
+    if (seqInfos.isEmpty()) {
+      return Optional.of(EMPTY_SEQUENCES);
+    }
+
+    seqInfos.sort(Comparator.comparingLong(SnapshotSeqInfo::getCreateSeqNum));
+    long[] createSeqNums = new long[seqInfos.size()];
+    UUID[] snapshotIds = new UUID[seqInfos.size()];
+    for (int i = 0; i < seqInfos.size(); i++) {
+      SnapshotSeqInfo seqInfo = seqInfos.get(i);
+      createSeqNums[i] = seqInfo.getCreateSeqNum();
+      snapshotIds[i] = seqInfo.getSnapshotId();
+    }
+    return Optional.of(new ActiveSnapshotSequences(createSeqNums, snapshotIds));
+  }
+
+  private static int lowerBound(long[] values, long target) {
+    int low = 0;
+    int high = values.length;
+    while (low < high) {
+      int mid = low + ((high - low) >>> 1);
+      if (values[mid] < target) {
+        low = mid + 1;
+      } else {
+        high = mid;
+      }
+    }
+    return low;
+  }
+
+  private void addExclusiveSize(UUID snapshotId, OmKeyInfo keyInfo) {
+    exclusiveSizeMap.compute(snapshotId,
+        (k, v) -> (v == null ? 0 : v) + keyInfo.getDataSize());
+    exclusiveReplicatedSizeMap.compute(snapshotId,
+        (k, v) -> (v == null ? 0 : v) + keyInfo.getReplicatedSize());
+  }
+
+  private void incrementSeqNumIntervalOptimized() {
+    DeletingServiceMetrics metrics = getOzoneManager().getDeletionMetrics();
+    if (metrics != null) {
+      metrics.incrSnapKeyReclaimIntervalOptimized();
+    }
+  }
+
+  private void incrementSeqNumIntervalFallback() {
+    DeletingServiceMetrics metrics = getOzoneManager().getDeletionMetrics();
+    if (metrics != null) {
+      metrics.incrSnapKeyReclaimIntervalFallback();
+    }
+  }
+
   /**
    * To calculate Exclusive Size for current snapshot, Check
    * the next snapshot deletedTable if the deleted key is
@@ -167,5 +333,41 @@ public class ReclaimableKeyFilter extends ReclaimableFilter<OmKeyInfo> {
       return Optional.empty();
     }
     return isBlockLocationInfoSame(prevKeyInfo, keyInfo) ? Optional.of(prevKeyInfo) : Optional.empty();
+  }
+
+  private static final class ActiveSnapshotSequences {
+    private final long[] createSeqNums;
+    private final UUID[] snapshotIds;
+
+    private ActiveSnapshotSequences(long[] createSeqNums, UUID[] snapshotIds) {
+      this.createSeqNums = createSeqNums;
+      this.snapshotIds = snapshotIds;
+    }
+
+    private long[] getCreateSeqNums() {
+      return createSeqNums;
+    }
+
+    private UUID[] getSnapshotIds() {
+      return snapshotIds;
+    }
+  }
+
+  private static final class SnapshotSeqInfo {
+    private final long createSeqNum;
+    private final UUID snapshotId;
+
+    private SnapshotSeqInfo(long createSeqNum, UUID snapshotId) {
+      this.createSeqNum = createSeqNum;
+      this.snapshotId = snapshotId;
+    }
+
+    private long getCreateSeqNum() {
+      return createSeqNum;
+    }
+
+    private UUID getSnapshotId() {
+      return snapshotId;
+    }
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/filter/TestReclaimableKeyFilter.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/filter/TestReclaimableKeyFilter.java
@@ -17,6 +17,7 @@
 
 package org.apache.hadoop.ozone.om.snapshot.filter;
 
+import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
@@ -24,22 +25,31 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLong;
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
+import org.apache.hadoop.hdds.utils.TransactionInfo;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.ozone.om.KeyManager;
 import org.apache.hadoop.ozone.om.OmSnapshot;
 import org.apache.hadoop.ozone.om.OmSnapshotManager;
 import org.apache.hadoop.ozone.om.OzoneManager;
+import org.apache.hadoop.ozone.om.SnapshotChainInfo;
 import org.apache.hadoop.ozone.om.SnapshotChainManager;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
 import org.apache.hadoop.ozone.om.lock.IOzoneManagerLock;
 import org.apache.hadoop.ozone.om.snapshot.SnapshotUtils;
 import org.apache.ratis.util.function.UncheckedAutoCloseableSupplier;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -159,6 +169,66 @@ public class TestReclaimableKeyFilter extends AbstractReclaimableFilterTest {
 
   private OmKeyInfo getMockedOmKeyInfo(long objectId) {
     return getMockedOmKeyInfo(objectId, 0, 0);
+  }
+
+  @Test
+  public void testSeqNumIntervalBoundaries() throws Exception {
+    setup(2, 3, 3, 1, 1, info -> {
+      int snapshotIndex = Integer.parseInt(info.getName().substring("snap".length()));
+      setCreateTransactionInfo(info, (snapshotIndex + 2L) * 10L);
+      return info;
+    }, BucketLayout.FILE_SYSTEM_OPTIMIZED);
+    String volume = getVolumes().get(0);
+    String bucket = getBuckets().get(0);
+    mockSnapshotChainPath(volume, bucket);
+
+    assertEquals(true, applySeqNumKey(volume, bucket, 10L, 20L));
+    assertEquals(false, applySeqNumKey(volume, bucket, 10L, 21L));
+    assertEquals(true, applySeqNumKey(volume, bucket, 40L, 40L));
+    assertEquals(true, applySeqNumKey(volume, bucket, 41L, 50L));
+  }
+
+  private Boolean applySeqNumKey(String volume, String bucket, long seqNumMin,
+      long seqNumMax) throws IOException {
+    OmKeyInfo keyInfo = new OmKeyInfo.Builder()
+        .setVolumeName(volume)
+        .setBucketName(bucket)
+        .setKeyName("key-" + seqNumMin + "-" + seqNumMax)
+        .setCreationTime(1L)
+        .setModificationTime(1L)
+        .setDataSize(1L)
+        .setReplicationConfig(RatisReplicationConfig.getInstance(ReplicationFactor.ONE))
+        .setSeqNumMin(seqNumMin)
+        .setSeqNumMax(seqNumMax)
+        .build();
+    return (Boolean) getReclaimableFilter().apply(Table.newKeyValue(keyInfo.getKeyName(), keyInfo));
+  }
+
+  private void mockSnapshotChainPath(String volume, String bucket)
+      throws IOException {
+    List<SnapshotInfo> snapshotInfos = getSnapshotInfos().get(getKey(volume, bucket));
+    LinkedHashMap<UUID, SnapshotChainInfo> chainPath = new LinkedHashMap<>();
+    UUID previousSnapshotId = null;
+    for (SnapshotInfo snapshotInfo : snapshotInfos) {
+      UUID snapshotId = snapshotInfo.getSnapshotId();
+      chainPath.put(snapshotId, new SnapshotChainInfo(snapshotId, previousSnapshotId, null));
+      if (previousSnapshotId != null) {
+        chainPath.get(previousSnapshotId).setNextSnapshotId(snapshotId);
+      }
+      previousSnapshotId = snapshotId;
+      when(getSnapshotChainManager().getTableKey(snapshotId)).thenReturn(snapshotInfo.getTableKey());
+    }
+    when(getSnapshotChainManager().getSnapshotChainPath(volume + OM_KEY_PREFIX + bucket))
+        .thenReturn(chainPath);
+  }
+
+  private void setCreateTransactionInfo(SnapshotInfo snapshotInfo, long transactionIndex) {
+    try {
+      snapshotInfo.setCreateTransactionInfo(
+          TransactionInfo.valueOf(TransactionInfo.getTermIndex(transactionIndex)).toByteString());
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
   }
 
   /**


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HDDS-15125

This pull request introduces MVCC-style sequence number intervals to improve snapshot key reclamation in Ozone. The main changes add `seqNumMin` and `seqNumMax` fields to `OmKeyInfo` and the protocol buffer, update the logic for setting these fields during key creation and deletion, and provide configuration and metrics to enable and monitor this optimization. Comprehensive tests are also added to verify correct behavior.

**MVCC Interval Support for Snapshot Key Reclamation:**

* Added `seqNumMin` and `seqNumMax` fields to `OmKeyInfo`, including builder methods, accessors, equality checks, and serialization/deserialization logic in both Java and protobuf definitions. These fields represent the sequence number interval for which a key version is visible, supporting more efficient snapshot key reclamation. [[1]](diffhunk://#diff-75beb1155ecb0d231931f0fc73e7f9008bba7363a0cc2ea2bef885cd69c80de3R114-R115) [[2]](diffhunk://#diff-75beb1155ecb0d231931f0fc73e7f9008bba7363a0cc2ea2bef885cd69c80de3R136-R137) [[3]](diffhunk://#diff-75beb1155ecb0d231931f0fc73e7f9008bba7363a0cc2ea2bef885cd69c80de3R206-R229) [[4]](diffhunk://#diff-75beb1155ecb0d231931f0fc73e7f9008bba7363a0cc2ea2bef885cd69c80de3R506-R507) [[5]](diffhunk://#diff-75beb1155ecb0d231931f0fc73e7f9008bba7363a0cc2ea2bef885cd69c80de3R536-R537) [[6]](diffhunk://#diff-75beb1155ecb0d231931f0fc73e7f9008bba7363a0cc2ea2bef885cd69c80de3R561-R562) [[7]](diffhunk://#diff-75beb1155ecb0d231931f0fc73e7f9008bba7363a0cc2ea2bef885cd69c80de3R739-R748) [[8]](diffhunk://#diff-75beb1155ecb0d231931f0fc73e7f9008bba7363a0cc2ea2bef885cd69c80de3R871-R876) [[9]](diffhunk://#diff-75beb1155ecb0d231931f0fc73e7f9008bba7363a0cc2ea2bef885cd69c80de3R933-R938) [[10]](diffhunk://#diff-75beb1155ecb0d231931f0fc73e7f9008bba7363a0cc2ea2bef885cd69c80de3R962-R963) [[11]](diffhunk://#diff-75beb1155ecb0d231931f0fc73e7f9008bba7363a0cc2ea2bef885cd69c80de3R982-R983) [[12]](diffhunk://#diff-31e34e282f9c79c316ed42775ccba5aba01cf10771bf8954e72ccc1e87d04a62R1200-R1205)

* Updated key commit and deletion logic to set `seqNumMin` and `seqNumMax` appropriately during key lifecycle events, ensuring the interval is tracked for MVCC-style reclaimability checks. [[1]](diffhunk://#diff-558df2fad1b82044cead7ecf5d4b767827f24e2cb991314b846b5b5e2a18d524R316) [[2]](diffhunk://#diff-a59ff516fafb8e800740f9630f8c985d6fe72c15418104b18e3d9b0c968664ebR234) [[3]](diffhunk://#diff-a59ff516fafb8e800740f9630f8c985d6fe72c15418104b18e3d9b0c968664ebR322-R324) [[4]](diffhunk://#diff-1a12ec76bd3be379b70f5cee5364e51d56d021af0ae2a835f466fc7441d9258eR643-R645) [[5]](diffhunk://#diff-1a12ec76bd3be379b70f5cee5364e51d56d021af0ae2a835f466fc7441d9258eR673-R675) [[6]](diffhunk://#diff-2841a017f8d700d802af1b1c49fea9ca281098728796384f5b2e79c23f09ab65R1188) [[7]](diffhunk://#diff-2841a017f8d700d802af1b1c49fea9ca281098728796384f5b2e79c23f09ab65R1199-R1209) [[8]](diffhunk://#diff-4f1696c15d45a47a935b94835f4285536f38cbf131b14eced06652a2e0eed5a4L523-R525)

**Configuration and Metrics:**

* Introduced a new configuration property `ozone.om.snapshot.key.reclaim.interval.enabled` (default: true) to enable the new reclaim logic, and added corresponding constants. [[1]](diffhunk://#diff-148cad3e4555d212af7e3c58a71fb17b2782587d89659f666227c6d92d7d898cR2432-R2444) [[2]](diffhunk://#diff-b20cc5762358eaa2ca49153f542f08a0fafbd0624dd144ec56d2cdb8fb4576c2R295-R299)

* Added new metrics to `DeletingServiceMetrics` to track the number of key reclaimability decisions optimized by seqNum intervals and those that fall back to legacy logic. [[1]](diffhunk://#diff-68835c93d2b81de5d7309e2797f10dc6b2098c85f1443d4e15b25a76abe689d8R112-R115) [[2]](diffhunk://#diff-68835c93d2b81de5d7309e2797f10dc6b2098c85f1443d4e15b25a76abe689d8R306-R321)

**Testing:**

* Added and extended unit tests in `TestOmKeyInfo` to verify correct preservation and behavior of the new interval fields during protobuf conversion and key deletion. [[1]](diffhunk://#diff-9ab50fda798e4c696f2739e770c3fcf71b6584c8513f167e09f2289b426ed29aR28) [[2]](diffhunk://#diff-9ab50fda798e4c696f2739e770c3fcf71b6584c8513f167e09f2289b426ed29aR45) [[3]](diffhunk://#diff-9ab50fda798e4c696f2739e770c3fcf71b6584c8513f167e09f2289b426ed29aR78-R133)

These changes collectively enable more efficient and accurate snapshot key reclamation by leveraging MVCC-style sequence number intervals, with configuration options and metrics to monitor and control the feature.


