### PR TITLE
HDDS-5195. Allow presigned PUT with unsigned ACL header

### DIFF
--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/signature/StringToSignProducer.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/signature/StringToSignProducer.java
@@ -57,6 +57,7 @@ import org.slf4j.LoggerFactory;
 public final class StringToSignProducer {
 
   public static final String X_AMAZ_DATE = "x-amz-date";
+  private static final String X_AMZ_ACL = "x-amz-acl";
   private static final Logger LOG =
       LoggerFactory.getLogger(StringToSignProducer.class);
   private static final Charset UTF_8 = StandardCharsets.UTF_8;
@@ -358,7 +359,7 @@ public final class StringToSignProducer {
   private static void validateCanonicalHeaders(
       String canonicalHeaders,
       Map<String, String> headers,
-      Boolean unsignedPaylod
+      boolean queryParameterAuth
   ) throws OS3Exception {
     if (!canonicalHeaders.contains(HOST + ":")) {
       LOG.error("The SignedHeaders list must include HTTP Host header");
@@ -372,6 +373,11 @@ public final class StringToSignProducer {
         // https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html
         // The x-amz-content-sha256 header is not required for CanonicalHeaders
         if (X_AMZ_CONTENT_SHA256.equals(header)) {
+          continue;
+        }
+        // Ozone does not currently apply canned ACLs from object PUT headers.
+        // Some clients still send x-amz-acl with query-presigned PUTs.
+        if (queryParameterAuth && X_AMZ_ACL.equals(header)) {
           continue;
         }
         LOG.error("The SignedHeaders list must include all "

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/signature/TestStringToSignProducer.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/signature/TestStringToSignProducer.java
@@ -74,7 +74,7 @@ public class TestStringToSignProducer {
         + "Content-SHA";
 
     String authHeader =
-        "AWS4-HMAC-SHA256 Credential=AKIAJWFJK62WUTKNFJJA/20181009/us-east-1"
+        "AWS4-HMAC-SHA256 Credential=OZONEEXAMPLEACCESSKEY/20181009/us-east-1"
             + "/s3/aws4_request, "
             + "SignedHeaders=host;x-amz-content-sha256;x-amz-date;"
             + "content-type, "
@@ -268,5 +268,35 @@ public class TestStringToSignProducer {
     }
 
     assertEquals(expectedResult, actualResult);
+  }
+
+  @Test
+  public void testPresignedUrlWithUnsignedAmzAclHeader() throws Exception {
+    Map<String, String> queryParams = new HashMap<>();
+    queryParams.put("X-Amz-Algorithm", "AWS4-HMAC-SHA256");
+    queryParams.put("X-Amz-Credential",
+        "OZONEEXAMPLEACCESSKEY/20130524/us-east-1/s3/aws4_request");
+    queryParams.put("X-Amz-Date", DATETIME);
+    queryParams.put("X-Amz-Expires", "600");
+    queryParams.put("X-Amz-SignedHeaders", "host");
+    queryParams.put("X-Amz-Signature",
+        "aeeed9bbccd4d02ee5c0109b86d86835f995330da4c265957d157751f604d404");
+
+    SignatureInfo signatureInfo =
+        new AuthorizationV4QueryParser(queryParams) {
+          @Override
+          protected void validateDateAndExpires() {
+            // noop
+          }
+        }.parseSignature();
+    signatureInfo.setUnfilteredURI("/bucket/key");
+
+    LowerCaseKeyStringMap headers = new LowerCaseKeyStringMap();
+    headers.put("host", "localhost");
+    headers.put("content-type", "application/octet-stream");
+    headers.put("x-amz-acl", "public-read");
+
+    StringToSignProducer.createSignatureBase(signatureInfo, "http", "PUT",
+        headers, queryParams);
   }
 }


### PR DESCRIPTION
## Summary
- allow query-presigned PUT requests to tolerate an unsigned `x-amz-acl` header
- add a regression test for the Mint Ruby presigned PUT request shape
- replace AWS-looking sample access key literals in the touched test file with a non-secret placeholder

## Root Cause
Mint Ruby generates a SigV4 query-presigned PUT URL with `X-Amz-SignedHeaders=host`, then sends `x-amz-acl: public-read` on the PUT. Ozone rejected the request during canonical header validation before reaching object PUT, although Ozone does not currently apply canned ACLs from object PUT headers.

## Validation
- `mvn -pl hadoop-ozone/s3gateway -Dtest=TestStringToSignProducer#testPresignedUrlWithUnsignedAmzAclHeader test`
- `mvn -pl hadoop-ozone/s3gateway -Dtest=TestStringToSignProducer test`
- `mvn -pl hadoop-ozone/s3gateway -Dtest=TestStringToSignProducer,TestAuthorizationV4QueryParser,TestAuthorizationV4HeaderParser,TestAuthorizationV2HeaderParser,TestAWSSignatureProcessor,TestAuthorizationFilter test`
- `mvn -pl hadoop-ozone/s3gateway test`

Refs peterxcli/ozone-s3-compatibility#7