### PR TITLE
Add handle for RC metrics

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/ContainerClientMetrics.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/ContainerClientMetrics.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hdds.scm;
 import com.google.common.annotations.VisibleForTesting;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.hadoop.hdds.protocol.DatanodeID;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
@@ -47,6 +48,29 @@ public final class ContainerClientMetrics {
   private static final String SOURCE_NAME =
       ContainerClientMetrics.class.getSimpleName();
   private static int instanceCount = 0;
+
+  /**
+   * Handle for one metrics acquisition.
+   */
+  public static final class Handle implements AutoCloseable {
+    private final ContainerClientMetrics metrics;
+    private final AtomicBoolean closed = new AtomicBoolean(false);
+
+    private Handle(ContainerClientMetrics metrics) {
+      this.metrics = metrics;
+    }
+
+    public ContainerClientMetrics metrics() {
+      return metrics;
+    }
+
+    @Override
+    public void close() {
+      if (closed.compareAndSet(false, true)) {
+        release();
+      }
+    }
+  }
 
   @Metric
   private MutableCounterLong totalWriteChunkCalls;
@@ -88,6 +112,10 @@ public final class ContainerClientMetrics {
     }
     referenceCount++;
     return instance;
+  }
+
+  public static Handle acquireHandle() {
+    return new Handle(acquire());
   }
 
   public static synchronized void release() {

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientManager.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientManager.java
@@ -62,8 +62,7 @@ public class XceiverClientManager extends XceiverClientCreator {
 
   private final Cache<String, XceiverClientSpi> clientCache;
   private final CacheMetrics cacheMetrics;
-
-  private static XceiverClientMetrics metrics;
+  private final XceiverClientMetrics.Handle metricsHandle;
 
   /**
    * Creates a new XceiverClientManager for non secured ozone cluster.
@@ -103,6 +102,7 @@ public class XceiverClientManager extends XceiverClientCreator {
           }).build();
 
     cacheMetrics = CacheMetrics.create(clientCache, this);
+    metricsHandle = XceiverClientMetrics.acquireHandle();
   }
 
   @VisibleForTesting
@@ -218,27 +218,21 @@ public class XceiverClientManager extends XceiverClientCreator {
       LOG.debug("XceiverClient cache stats: {}", clientCache.stats());
     }
     cacheMetrics.unregister();
-
-    if (metrics != null) {
-      metrics.unRegister();
-    }
+    metricsHandle.close();
   }
 
   /**
    * Get xceiver client metric.
    */
   public static synchronized XceiverClientMetrics getXceiverClientMetrics() {
-    if (metrics == null) {
-      metrics = XceiverClientMetrics.create();
-    }
-
-    return metrics;
+    return XceiverClientMetrics.create();
   }
 
   /**
    * Reset xceiver client metric.
    */
   public static synchronized void resetXceiverClientMetrics() {
+    XceiverClientMetrics metrics = XceiverClientMetrics.getInstance();
     if (metrics != null) {
       metrics.reset();
     }

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientMetrics.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientMetrics.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hdds.scm;
 
 import com.google.common.annotations.VisibleForTesting;
 import java.util.EnumMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
@@ -43,6 +44,33 @@ import org.apache.hadoop.ozone.util.PerformanceMetrics;
 public class XceiverClientMetrics implements MetricsSource {
   public static final String SOURCE_NAME = XceiverClientMetrics.class
       .getSimpleName();
+
+  private static XceiverClientMetrics instance;
+  @VisibleForTesting
+  static int referenceCount = 0;
+
+  /**
+   * Handle for one metrics acquisition.
+   */
+  public static final class Handle implements AutoCloseable {
+    private final XceiverClientMetrics metrics;
+    private final AtomicBoolean closed = new AtomicBoolean(false);
+
+    private Handle(XceiverClientMetrics metrics) {
+      this.metrics = metrics;
+    }
+
+    public XceiverClientMetrics metrics() {
+      return metrics;
+    }
+
+    @Override
+    public void close() {
+      if (closed.compareAndSet(false, true)) {
+        release();
+      }
+    }
+  }
 
   private @Metric MutableCounterLong pendingOps;
   private @Metric MutableCounterLong totalOps;
@@ -79,11 +107,36 @@ public class XceiverClientMetrics implements MetricsSource {
     }
   }
 
-  public static XceiverClientMetrics create() {
+  public static synchronized XceiverClientMetrics create() {
+    if (instance != null) {
+      return instance;
+    }
     DefaultMetricsSystem.initialize(SOURCE_NAME);
     MetricsSystem ms = DefaultMetricsSystem.instance();
-    return ms.register(SOURCE_NAME, "Storage Container Client Metrics",
+    instance = ms.register(SOURCE_NAME, "Storage Container Client Metrics",
         new XceiverClientMetrics());
+    return instance;
+  }
+
+  static synchronized XceiverClientMetrics getInstance() {
+    return instance;
+  }
+
+  public static synchronized Handle acquireHandle() {
+    XceiverClientMetrics metrics = create();
+    referenceCount++;
+    return new Handle(metrics);
+  }
+
+  static synchronized void release() {
+    if (referenceCount > 0) {
+      referenceCount--;
+    }
+    if (referenceCount == 0 && instance != null) {
+      XceiverClientMetrics metrics = instance;
+      instance = null;
+      metrics.unregisterSource();
+    }
   }
 
   public void incrPendingContainerOpsMetrics(ContainerProtos.Type type) {
@@ -131,6 +184,16 @@ public class XceiverClientMetrics implements MetricsSource {
   }
 
   public void unRegister() {
+    synchronized (XceiverClientMetrics.class) {
+      if (instance == this) {
+        instance = null;
+        referenceCount = 0;
+      }
+    }
+    unregisterSource();
+  }
+
+  private void unregisterSource() {
     IOUtils.closeQuietly(containerOpsLatency.values());
     MetricsSystem ms = DefaultMetricsSystem.instance();
     ms.unregisterSource(SOURCE_NAME);

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/TestContainerClientMetrics.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/TestContainerClientMetrics.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hdds.scm;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 
@@ -27,6 +28,7 @@ import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.protocol.DatanodeID;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -35,7 +37,8 @@ import org.junit.jupiter.api.Test;
  */
 public class TestContainerClientMetrics {
   @BeforeEach
-  public void setup() {
+  @AfterEach
+  public void resetMetrics() {
     while (ContainerClientMetrics.referenceCount > 0) {
       ContainerClientMetrics.release();
     }
@@ -101,6 +104,42 @@ public class TestContainerClientMetrics {
 
     ContainerClientMetrics.acquire();
     assertNotNull(ContainerClientMetrics.acquire());
+  }
+
+  @Test
+  public void testAcquireHandleReleasesOnlyOnce() {
+    ContainerClientMetrics.Handle handle =
+        ContainerClientMetrics.acquireHandle();
+
+    assertNotNull(handle.metrics());
+    assertEquals(1, ContainerClientMetrics.referenceCount);
+
+    handle.close();
+    assertEquals(0, ContainerClientMetrics.referenceCount);
+
+    handle.close();
+    assertEquals(0, ContainerClientMetrics.referenceCount);
+    assertThrows(IllegalStateException.class, ContainerClientMetrics::release);
+  }
+
+  @Test
+  public void testMultipleAcquireHandlesReleaseIndependently() {
+    ContainerClientMetrics.Handle handle1 =
+        ContainerClientMetrics.acquireHandle();
+    ContainerClientMetrics.Handle handle2 =
+        ContainerClientMetrics.acquireHandle();
+
+    assertSame(handle1.metrics(), handle2.metrics());
+    assertEquals(2, ContainerClientMetrics.referenceCount);
+
+    handle1.close();
+    assertEquals(1, ContainerClientMetrics.referenceCount);
+
+    handle1.close();
+    assertEquals(1, ContainerClientMetrics.referenceCount);
+
+    handle2.close();
+    assertEquals(0, ContainerClientMetrics.referenceCount);
   }
 
   private Pipeline createPipeline(PipelineID piplineId, DatanodeID leaderId) {

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/TestXceiverClientMetricsLifecycle.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/TestXceiverClientMetricsLifecycle.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.io.IOException;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class TestXceiverClientMetricsLifecycle {
+
+  @BeforeEach
+  @AfterEach
+  void resetMetrics() {
+    while (XceiverClientMetrics.referenceCount > 0) {
+      XceiverClientMetrics.release();
+    }
+  }
+
+  @Test
+  void acquireHandleReleasesOnlyOnce() {
+    XceiverClientMetrics.Handle handle =
+        XceiverClientMetrics.acquireHandle();
+
+    assertEquals(1, XceiverClientMetrics.referenceCount);
+
+    handle.close();
+    assertEquals(0, XceiverClientMetrics.referenceCount);
+
+    handle.close();
+    assertEquals(0, XceiverClientMetrics.referenceCount);
+  }
+
+  @Test
+  void managerCloseReleasesMetricsOnlyWhenLastManagerCloses()
+      throws IOException {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    XceiverClientManager first = null;
+    XceiverClientManager second = null;
+    boolean firstClosed = false;
+
+    try {
+      first = new XceiverClientManager(conf);
+      second = new XceiverClientManager(conf);
+      XceiverClientMetrics metrics =
+          XceiverClientManager.getXceiverClientMetrics();
+
+      assertEquals(2, XceiverClientMetrics.referenceCount);
+
+      first.close();
+      firstClosed = true;
+
+      assertEquals(1, XceiverClientMetrics.referenceCount);
+      assertSame(metrics, XceiverClientManager.getXceiverClientMetrics());
+    } finally {
+      if (!firstClosed && first != null) {
+        first.close();
+      }
+      if (second != null) {
+        second.close();
+      }
+    }
+
+    assertEquals(0, XceiverClientMetrics.referenceCount);
+  }
+}

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestBlockOutputStreamCorrectness.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestBlockOutputStreamCorrectness.java
@@ -77,13 +77,17 @@ class TestBlockOutputStreamCorrectness {
 
     final BufferPool bufferPool = new BufferPool(4 * 1024 * 1024, 32 / 4);
 
-    for (int block = 0; block < 10; block++) {
-      try (BlockOutputStream outputStream = createBlockOutputStream(bufferPool)) {
-        for (int i = 0; i < DATA_SIZE / writeSize; i++) {
-          if (writeSize > 1) {
-            outputStream.write(DATA, i * writeSize, writeSize);
-          } else {
-            outputStream.write(DATA[i]);
+    try (ContainerClientMetrics.Handle metrics =
+        ContainerClientMetrics.acquireHandle()) {
+      for (int block = 0; block < 10; block++) {
+        try (BlockOutputStream outputStream =
+            createBlockOutputStream(bufferPool, metrics.metrics())) {
+          for (int i = 0; i < DATA_SIZE / writeSize; i++) {
+            if (writeSize > 1) {
+              outputStream.write(DATA, i * writeSize, writeSize);
+            } else {
+              outputStream.write(DATA[i]);
+            }
           }
         }
       }
@@ -125,8 +129,11 @@ class TestBlockOutputStreamCorrectness {
     should not throw an exception because of missing stripeChecksum.
      */
     BlockData[] blockData = createBlockDataWithoutStripeChecksum(blockID, replicationConfig);
-    try (ECBlockOutputStream ecBlockOutputStream = createECBlockOutputStream(config, replicationConfig, blockID,
-        pipeline)) {
+    try (ContainerClientMetrics.Handle metrics =
+        ContainerClientMetrics.acquireHandle();
+         ECBlockOutputStream ecBlockOutputStream =
+             createECBlockOutputStream(config, replicationConfig, blockID,
+                 pipeline, metrics.metrics())) {
       Assertions.assertDoesNotThrow(() -> ecBlockOutputStream.executePutBlock(true, true, locationInfo.getLength(),
           blockData));
     }
@@ -150,7 +157,8 @@ class TestBlockOutputStreamCorrectness {
     return blockDataArray;
   }
 
-  private BlockOutputStream createBlockOutputStream(BufferPool bufferPool)
+  private BlockOutputStream createBlockOutputStream(BufferPool bufferPool,
+      ContainerClientMetrics clientMetrics)
       throws IOException {
 
     final Pipeline pipeline = MockPipeline.createRatisPipeline();
@@ -177,18 +185,18 @@ class TestBlockOutputStreamCorrectness {
         bufferPool,
         config,
         null,
-        ContainerClientMetrics.acquire(),
+        clientMetrics,
         streamBufferArgs,
         () -> newFixedThreadPool(10));
   }
 
   private ECBlockOutputStream createECBlockOutputStream(OzoneClientConfig clientConfig,
-      ECReplicationConfig repConfig, BlockID blockID, Pipeline pipeline) throws IOException {
+      ECReplicationConfig repConfig, BlockID blockID, Pipeline pipeline,
+      ContainerClientMetrics clientMetrics) throws IOException {
     final XceiverClientManager xcm = mock(XceiverClientManager.class);
     when(xcm.acquireClient(any()))
         .thenReturn(new MockXceiverClientSpi(pipeline));
 
-    ContainerClientMetrics clientMetrics = ContainerClientMetrics.acquire();
     StreamBufferArgs streamBufferArgs =
         StreamBufferArgs.getDefaultStreamBufferArgs(repConfig, clientConfig);
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/BlockDeletingServiceMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/BlockDeletingServiceMetrics.java
@@ -17,6 +17,8 @@
 
 package org.apache.hadoop.ozone.container.common.helpers;
 
+import com.google.common.annotations.VisibleForTesting;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.hadoop.metrics2.MetricsSystem;
 import org.apache.hadoop.metrics2.annotation.Metric;
 import org.apache.hadoop.metrics2.annotation.Metrics;
@@ -33,8 +35,33 @@ import org.apache.hadoop.ozone.container.common.impl.BlockDeletingService;
 public final class BlockDeletingServiceMetrics {
 
   private static BlockDeletingServiceMetrics instance;
+  @VisibleForTesting
+  static int referenceCount = 0;
   public static final String SOURCE_NAME =
       BlockDeletingService.class.getSimpleName();
+
+  /**
+   * Handle for one metrics acquisition.
+   */
+  public static final class Handle implements AutoCloseable {
+    private final BlockDeletingServiceMetrics metrics;
+    private final AtomicBoolean closed = new AtomicBoolean(false);
+
+    private Handle(BlockDeletingServiceMetrics metrics) {
+      this.metrics = metrics;
+    }
+
+    public BlockDeletingServiceMetrics metrics() {
+      return metrics;
+    }
+
+    @Override
+    public void close() {
+      if (closed.compareAndSet(false, true)) {
+        unRegister();
+      }
+    }
+  }
 
   @Metric(about = "The number of successful delete blocks")
   private MutableCounterLong successCount;
@@ -97,13 +124,27 @@ public final class BlockDeletingServiceMetrics {
     return instance;
   }
 
+  public static Handle acquireHandle() {
+    return new Handle(acquire());
+  }
+
+  private static synchronized BlockDeletingServiceMetrics acquire() {
+    referenceCount++;
+    return create();
+  }
+
   /**
    * Unregister the metrics instance.
    */
   public static synchronized void unRegister() {
-    instance = null;
-    MetricsSystem ms = DefaultMetricsSystem.instance();
-    ms.unregisterSource(SOURCE_NAME);
+    if (referenceCount > 0) {
+      referenceCount--;
+    }
+    if (referenceCount == 0 && instance != null) {
+      instance = null;
+      MetricsSystem ms = DefaultMetricsSystem.instance();
+      ms.unregisterSource(SOURCE_NAME);
+    }
   }
 
   public void incrSuccessCount(long count) {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/BlockDeletingService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/BlockDeletingService.java
@@ -66,6 +66,7 @@ public class BlockDeletingService extends BackgroundService {
   private final ContainerDeletionChoosingPolicy containerDeletionPolicy;
   private final ConfigurationSource conf;
   private final DatanodeConfiguration dnConf;
+  private final BlockDeletingServiceMetrics.Handle metricsHandle;
   private final BlockDeletingServiceMetrics metrics;
 
   // Task priority is useful when a to-delete block has weight.
@@ -110,7 +111,8 @@ public class BlockDeletingService extends BackgroundService {
     }
     this.blockDeletingMaxLockHoldingTime =
         dnConf.getBlockDeletingMaxLockHoldingTime();
-    metrics = BlockDeletingServiceMetrics.create();
+    metricsHandle = BlockDeletingServiceMetrics.acquireHandle();
+    metrics = metricsHandle.metrics();
   }
 
   public void registerReconfigCallbacks(ReconfigurationHandler handler) {
@@ -143,6 +145,12 @@ public class BlockDeletingService extends BackgroundService {
       setServiceTimeoutInNanos(newTimeout);
       start();
     }
+  }
+
+  @Override
+  public synchronized void shutdown() {
+    super.shutdown();
+    metricsHandle.close();
   }
 
   /**

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteBlocksCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteBlocksCommandHandler.java
@@ -91,6 +91,7 @@ public class DeleteBlocksCommandHandler implements CommandHandler {
   private final LinkedBlockingQueue<DeleteCmdInfo> deleteCommandQueues;
   private final Daemon handlerThread;
   private final OzoneContainer ozoneContainer;
+  private final BlockDeletingServiceMetrics.Handle blockDeleteMetricsHandle;
   private final BlockDeletingServiceMetrics blockDeleteMetrics;
   private final long tryLockTimeoutMs;
   private final Map<String, SchemaHandler> schemaHandlers;
@@ -102,7 +103,8 @@ public class DeleteBlocksCommandHandler implements CommandHandler {
     this.ozoneContainer = container;
     this.containerSet = container.getContainerSet();
     this.conf = conf;
-    this.blockDeleteMetrics = BlockDeletingServiceMetrics.create();
+    this.blockDeleteMetricsHandle = BlockDeletingServiceMetrics.acquireHandle();
+    this.blockDeleteMetrics = blockDeleteMetricsHandle.metrics();
     this.tryLockTimeoutMs = dnConf.getBlockDeleteMaxLockWaitTimeoutMs();
     schemaHandlers = new HashMap<>();
     schemaHandlers.put(SCHEMA_V1, this::markBlocksForDeletionSchemaV1);
@@ -742,6 +744,7 @@ public class DeleteBlocksCommandHandler implements CommandHandler {
         Thread.currentThread().interrupt();
       }
     }
+    blockDeleteMetricsHandle.close();
   }
 
   private interface DeletionMarker {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ec/reconstruction/ECReconstructionCoordinator.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ec/reconstruction/ECReconstructionCoordinator.java
@@ -110,6 +110,7 @@ public class ECReconstructionCoordinator implements Closeable {
   private final MemoizedSupplier<ExecutorService> ecReconstructWriteExecutor;
   private final BlockInputStreamFactory blockInputStreamFactory;
   private final TokenHelper tokenHelper;
+  private final ContainerClientMetrics.Handle clientMetricsHandle;
   private final ContainerClientMetrics clientMetrics;
   private final ECReconstructionMetrics metrics;
   private final StateContext context;
@@ -137,7 +138,8 @@ public class ECReconstructionCoordinator implements Closeable {
     this.blockInputStreamFactory = BlockInputStreamFactoryImpl
         .getInstance(byteBufferPool, () -> ecReconstructReadExecutor);
     tokenHelper = new TokenHelper(new SecurityConfig(conf), secretKeyClient);
-    this.clientMetrics = ContainerClientMetrics.acquire();
+    this.clientMetricsHandle = ContainerClientMetrics.acquireHandle();
+    this.clientMetrics = clientMetricsHandle.metrics();
     this.metrics = metrics;
   }
 
@@ -449,13 +451,20 @@ public class ECReconstructionCoordinator implements Closeable {
 
   @Override
   public void close() throws IOException {
-    if (containerOperationClient != null) {
-      containerOperationClient.close();
+    try {
+      if (containerOperationClient != null) {
+        containerOperationClient.close();
+      }
+    } finally {
+      try {
+        if (ecReconstructWriteExecutor.isInitialized()) {
+          ecReconstructWriteExecutor.get().shutdownNow();
+        }
+        ecReconstructReadExecutor.shutdownNow();
+      } finally {
+        clientMetricsHandle.close();
+      }
     }
-    if (ecReconstructWriteExecutor.isInitialized()) {
-      ecReconstructWriteExecutor.get().shutdownNow();
-    }
-    ecReconstructReadExecutor.shutdownNow();
   }
 
   private Pipeline rebuildInputPipeline(ECReplicationConfig repConfig,

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/hdds/scm/TestECReconstructionCoordinatorMetrics.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/hdds/scm/TestECReconstructionCoordinatorMetrics.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+
+import java.io.IOException;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.container.common.statemachine.DatanodeStateMachine;
+import org.apache.hadoop.ozone.container.common.statemachine.StateContext;
+import org.apache.hadoop.ozone.container.ec.reconstruction.ECReconstructionCoordinator;
+import org.apache.hadoop.ozone.container.ec.reconstruction.ECReconstructionMetrics;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests ContainerClientMetrics lifecycle in ECReconstructionCoordinator.
+ */
+class TestECReconstructionCoordinatorMetrics {
+
+  @BeforeEach
+  @AfterEach
+  void resetMetrics() {
+    while (ContainerClientMetrics.referenceCount > 0) {
+      ContainerClientMetrics.release();
+    }
+  }
+
+  @Test
+  void closeReleasesContainerClientMetrics() throws IOException {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    DatanodeStateMachine stateMachine = mock(DatanodeStateMachine.class);
+    StateContext context = new StateContext(conf,
+        DatanodeStateMachine.DatanodeStates.getInitState(), stateMachine, "");
+    ECReconstructionMetrics metrics = ECReconstructionMetrics.create();
+
+    try (ECReconstructionCoordinator coordinator =
+        new ECReconstructionCoordinator(conf, null, null, context, metrics,
+            "")) {
+      assertEquals(1, ContainerClientMetrics.referenceCount);
+    } finally {
+      metrics.unRegister();
+    }
+
+    assertEquals(0, ContainerClientMetrics.referenceCount);
+  }
+}

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/helpers/TestBlockDeletingServiceMetrics.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/helpers/TestBlockDeletingServiceMetrics.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.container.common.helpers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class TestBlockDeletingServiceMetrics {
+
+  @BeforeEach
+  @AfterEach
+  void resetMetrics() {
+    while (BlockDeletingServiceMetrics.referenceCount > 0) {
+      BlockDeletingServiceMetrics.unRegister();
+    }
+  }
+
+  @Test
+  void acquireHandleReleasesOnlyOnce() {
+    BlockDeletingServiceMetrics.Handle handle =
+        BlockDeletingServiceMetrics.acquireHandle();
+
+    assertEquals(1, BlockDeletingServiceMetrics.referenceCount);
+
+    handle.close();
+    assertEquals(0, BlockDeletingServiceMetrics.referenceCount);
+
+    handle.close();
+    assertEquals(0, BlockDeletingServiceMetrics.referenceCount);
+  }
+
+  @Test
+  void multipleAcquireHandlesReleaseIndependently() {
+    BlockDeletingServiceMetrics.Handle first =
+        BlockDeletingServiceMetrics.acquireHandle();
+    BlockDeletingServiceMetrics.Handle second =
+        BlockDeletingServiceMetrics.acquireHandle();
+
+    assertSame(first.metrics(), second.metrics());
+    assertEquals(2, BlockDeletingServiceMetrics.referenceCount);
+
+    first.close();
+    assertEquals(1, BlockDeletingServiceMetrics.referenceCount);
+
+    first.close();
+    assertEquals(1, BlockDeletingServiceMetrics.referenceCount);
+
+    second.close();
+    assertEquals(0, BlockDeletingServiceMetrics.referenceCount);
+  }
+}

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBMetrics.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBMetrics.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hdds.utils.db;
 
 import com.google.common.annotations.VisibleForTesting;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.hadoop.metrics2.MetricsSystem;
 import org.apache.hadoop.metrics2.annotation.Metric;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
@@ -31,6 +32,31 @@ public class RDBMetrics {
   private static final String SOURCE_NAME = RDBMetrics.class.getSimpleName();
 
   private static RDBMetrics instance;
+  @VisibleForTesting
+  static int referenceCount = 0;
+
+  /**
+   * Handle for one metrics acquisition.
+   */
+  public static final class Handle implements AutoCloseable {
+    private final RDBMetrics metrics;
+    private final AtomicBoolean closed = new AtomicBoolean(false);
+
+    private Handle(RDBMetrics metrics) {
+      this.metrics = metrics;
+    }
+
+    public RDBMetrics metrics() {
+      return metrics;
+    }
+
+    @Override
+    public void close() {
+      if (closed.compareAndSet(false, true)) {
+        unRegister();
+      }
+    }
+  }
 
   private @Metric MutableCounterLong numDBKeyMayExistChecks;
   private @Metric MutableCounterLong numDBKeyMayExistMisses;
@@ -55,6 +81,15 @@ public class RDBMetrics {
         "Rocks DB Metrics",
         new RDBMetrics());
     return instance;
+  }
+
+  public static Handle acquireHandle() {
+    return new Handle(acquire());
+  }
+
+  private static synchronized RDBMetrics acquire() {
+    referenceCount++;
+    return create();
   }
 
   public long getNumDBKeyGets() {
@@ -124,9 +159,14 @@ public class RDBMetrics {
   }
 
   public static synchronized void unRegister() {
-    instance = null;
-    MetricsSystem ms = DefaultMetricsSystem.instance();
-    ms.unregisterSource(SOURCE_NAME);
+    if (referenceCount > 0) {
+      referenceCount--;
+    }
+    if (referenceCount == 0 && instance != null) {
+      instance = null;
+      MetricsSystem ms = DefaultMetricsSystem.instance();
+      ms.unregisterSource(SOURCE_NAME);
+    }
   }
 
 }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
@@ -69,6 +69,7 @@ public class RDBStore implements DBStore {
   private final RDBCheckpointManager checkPointManager;
   private final String checkpointsParentDir;
   private final String snapshotsParentDir;
+  private final RDBMetrics.Handle rdbMetricsHandle;
   private final RDBMetrics rdbMetrics;
   private final RocksDBCheckpointDiffer rocksDBCheckpointDiffer;
 
@@ -175,7 +176,8 @@ public class RDBStore implements DBStore {
 
       //Initialize checkpoint manager
       checkPointManager = new RDBCheckpointManager(db, dbLocation.getName());
-      rdbMetrics = RDBMetrics.create();
+      rdbMetricsHandle = RDBMetrics.acquireHandle();
+      rdbMetrics = rdbMetricsHandle.metrics();
     } catch (IOException | RuntimeException e) {
       try {
         close();
@@ -245,7 +247,9 @@ public class RDBStore implements DBStore {
       metrics = null;
     }
 
-    RDBMetrics.unRegister();
+    if (rdbMetricsHandle != null) {
+      rdbMetricsHandle.close();
+    }
     IOUtils.close(LOG, checkPointManager);
     if (rocksDBCheckpointDiffer != null) {
       RocksDBCheckpointDifferHolder

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBMetrics.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBMetrics.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.utils.db;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class TestRDBMetrics {
+
+  @BeforeEach
+  @AfterEach
+  void resetMetrics() {
+    while (RDBMetrics.referenceCount > 0) {
+      RDBMetrics.unRegister();
+    }
+  }
+
+  @Test
+  void acquireHandleReleasesOnlyOnce() {
+    RDBMetrics.Handle handle = RDBMetrics.acquireHandle();
+
+    assertEquals(1, RDBMetrics.referenceCount);
+
+    handle.close();
+    assertEquals(0, RDBMetrics.referenceCount);
+
+    handle.close();
+    assertEquals(0, RDBMetrics.referenceCount);
+  }
+
+  @Test
+  void multipleAcquireHandlesReleaseIndependently() {
+    RDBMetrics.Handle first = RDBMetrics.acquireHandle();
+    RDBMetrics.Handle second = RDBMetrics.acquireHandle();
+
+    assertSame(first.metrics(), second.metrics());
+    assertEquals(2, RDBMetrics.referenceCount);
+
+    first.close();
+    assertEquals(1, RDBMetrics.referenceCount);
+
+    first.close();
+    assertEquals(1, RDBMetrics.referenceCount);
+
+    second.close();
+    assertEquals(0, RDBMetrics.referenceCount);
+  }
+}

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -220,6 +220,7 @@ public class RpcClient implements ClientProtocol {
   private final BlockInputStreamFactory blockInputStreamFactory;
   private final OzoneManagerVersion omVersion;
   private final MemoizedSupplier<ExecutorService> ecReconstructExecutor;
+  private final ContainerClientMetrics.Handle clientMetricsHandle;
   private final ContainerClientMetrics clientMetrics;
   private final MemoizedSupplier<ExecutorService> writeExecutor;
   private volatile OzoneFsServerDefaults serverDefaults;
@@ -328,7 +329,8 @@ public class RpcClient implements ClientProtocol {
     this.byteBufferPool = new BoundedElasticByteBufferPool(maxPoolSize);
     this.blockInputStreamFactory = BlockInputStreamFactoryImpl
         .getInstance(byteBufferPool, ecReconstructExecutor);
-    this.clientMetrics = ContainerClientMetrics.acquire();
+    this.clientMetricsHandle = ContainerClientMetrics.acquireHandle();
+    this.clientMetrics = clientMetricsHandle.metrics();
 
     this.serverDefaultsValidityPeriod = conf.getTimeDuration(
         OZONE_CLIENT_SERVER_DEFAULTS_VALIDITY_PERIOD_MS,
@@ -1957,7 +1959,7 @@ public class RpcClient implements ClientProtocol {
     IOUtils.cleanupWithLogger(LOG, ozoneManagerClient, xceiverClientManager);
     keyProviderCache.invalidateAll();
     keyProviderCache.cleanUp();
-    ContainerClientMetrics.release();
+    clientMetricsHandle.close();
   }
 
   @Deprecated


### PR DESCRIPTION
This pull request introduces a new reference-counted handle pattern for managing the lifecycle of `ContainerClientMetrics` and `XceiverClientMetrics`, ensuring safer registration and unregistration of metrics. It also adds comprehensive agent instructions for contributors, updates repository metadata, and improves test coverage for the new handle logic.

**Metrics Lifecycle Management Improvements:**

* Introduced a reference-counted `Handle` class for both `ContainerClientMetrics` and `XceiverClientMetrics`, allowing for safer acquisition and release of metrics through RAII-style handles. This prevents premature or double unregistration and ensures metrics are only unregistered when all handles are closed. [[1]](diffhunk://#diff-41f886ec87dffb1ea0c883c42da5fa6b781133e625b0261e18a6c240b4a5f422R52-R74) [[2]](diffhunk://#diff-41f886ec87dffb1ea0c883c42da5fa6b781133e625b0261e18a6c240b4a5f422R117-R120) [[3]](diffhunk://#diff-5ad03287c19a1c43ee17e4564f172942eac4c0f823d558cd552834c2de4404f5R48-R74) [[4]](diffhunk://#diff-5ad03287c19a1c43ee17e4564f172942eac4c0f823d558cd552834c2de4404f5L82-R139) [[5]](diffhunk://#diff-5ad03287c19a1c43ee17e4564f172942eac4c0f823d558cd552834c2de4404f5R187-R196)
* Updated `XceiverClientManager` to use the new handle-based metrics management, eliminating static field misuse and ensuring proper cleanup in `close()`. [[1]](diffhunk://#diff-cb461f01f9e534b8a4ea12745c29b0ef625c4f5017363c479c0733c0044c82a2L65-R65) [[2]](diffhunk://#diff-cb461f01f9e534b8a4ea12745c29b0ef625c4f5017363c479c0733c0044c82a2R105) [[3]](diffhunk://#diff-cb461f01f9e534b8a4ea12745c29b0ef625c4f5017363c479c0733c0044c82a2L221-R235)

**Testing Enhancements:**

* Added and improved unit tests in `TestContainerClientMetrics` to verify correct handle acquisition, release, and idempotency, ensuring the new metrics lifecycle logic is robust. [[1]](diffhunk://#diff-69f6107d6c92abd9fc704997a4d8c7434c794cd02f1aa9c3c1d221c2f2e1d2fcR22) [[2]](diffhunk://#diff-69f6107d6c92abd9fc704997a4d8c7434c794cd02f1aa9c3c1d221c2f2e1d2fcR31) [[3]](diffhunk://#diff-69f6107d6c92abd9fc704997a4d8c7434c794cd02f1aa9c3c1d221c2f2e1d2fcL38-R41) [[4]](diffhunk://#diff-69f6107d6c92abd9fc704997a4d8c7434c794cd02f1aa9c3c1d221c2f2e1d2fcR109-R144)

**Documentation and Contributor Guidance:**

* Added a comprehensive `AGENTS.md` file detailing working style, repository structure, build/test commands, coding/testing standards, and PR guidelines for contributors.
* Included `AGENTS.md` in the project metadata and exclusion lists for RAT/license checks, and referenced it in `CLAUDE.md`. [[1]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R1) [[2]](diffhunk://#diff-53d0b5e3adb1989da294637d7f3cdef793d5c94ddf14c395d2c76ad086b98f5eR21-R22)

**Dependency and Import Updates:**

* Added necessary imports for `AtomicBoolean` in relevant Java files to support the new handle logic. [[1]](diffhunk://#diff-41f886ec87dffb1ea0c883c42da5fa6b781133e625b0261e18a6c240b4a5f422R23) [[2]](diffhunk://#diff-5ad03287c19a1c43ee17e4564f172942eac4c0f823d558cd552834c2de4404f5R22)